### PR TITLE
Remove covr from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,6 @@ Remotes:
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Suggests: 
-    covr,
     knitr,
     rmarkdown,
     testthat (>= 3.0.0)


### PR DESCRIPTION
The same way we don't include pkgdown in `Suggests`, we shouldn't include covr, which is only used as part of a user-invisible development process. This also removes some of the reverse dependency checking burden for this package.