### PR TITLE
do not modify user-specified column names when cleaning column name

### DIFF
--- a/R/clean_col_names.R
+++ b/R/clean_col_names.R
@@ -3,35 +3,60 @@
 #' @param x the input data frame
 #' @param report a list with the information about the effects of the
 #'          the cleaning steps
+#' @param keep_col_names a vector of column names to be kept as there appear in
+#'    the original data. default is `NULL`.
 #'
 #' @return the a list with 2 elements: input data frame with a knit column names
 #'          and the report object
 #' @keywords internal
 #' @noRd
 #'
-clean_col_names <- function(x, report = list()) {
+clean_col_names <- function(x, report = list(), keep_col_names = NULL) {
   original_names <- col_names <- colnames(x)
-  # standardize the column names
-  col_names <- snakecase::to_snake_case(col_names)
-  cleaned_names <- epitrix::clean_labels(col_names)
 
-  # make column name unique
-  unique_names <- make.unique(cleaned_names, sep = "_")
+  # in case the user wants to keep some column names as they are,
+  # they should be provided as value for the keep_col_names arguments.
+  # here we will make sure to spare those column names from been modified
+
+  # check if the column names to be kept exist
+  if (!is.null(keep_col_names)) {
+    stopifnot("\nIncorrect column names were provided: " =
+                all(keep_col_names %in% original_names))
+  }
+
+  # get the indexes of the column names to not change
+  idx               <- match(keep_col_names, original_names)
+
+  # We have opted for snake case in the column names. Thus, all camel cases will
+  # be converted into snake cases.
+  if (length(idx) > 0L) {
+    tmp_col_names   <- snakecase::to_snake_case(col_names[-idx])
+    cleaned_names   <- epitrix::clean_labels(tmp_col_names)
+    # make column name unique
+    unique_names    <- make.unique(cleaned_names, sep = "_")
+    # update the column names
+    col_names[-idx] <- unique_names
+  } else {
+    col_names       <- snakecase::to_snake_case(col_names)
+    col_names       <- epitrix::clean_labels(col_names)
+    # make column name unique
+    col_names       <- make.unique(col_names, sep = "_")
+  }
 
   # detect modified column names from the previous command
-  original_name <- new_name <- NULL
-  xx <- as.data.frame(cbind(original_name = original_names,
-                            new_name = unique_names)) %>%
+  original_name     <- new_name <- NULL
+  xx  <- as.data.frame(cbind(original_name = original_names,
+                             new_name      = col_names)) %>%
     dplyr::mutate(original_name = as.character(original_name),
-                  new_name = as.character(new_name))
+                  new_name      = as.character(new_name))
   idx <- which(xx[["original_name"]] != xx[["new_name"]])
   if (length(idx) > 0L) {
     report[["modified_column_names"]] <- xx[idx, ]
   }
 
-  names(x) <- unique_names
+  names(x) <- col_names
   list(
-    data = x,
+    data   = x,
     report = report
   )
 }

--- a/R/clean_col_names.R
+++ b/R/clean_col_names.R
@@ -3,52 +3,57 @@
 #' @param x the input data frame
 #' @param report a list with the information about the effects of the
 #'          the cleaning steps
-#' @param keep_col_names a vector of column names to be kept as there appear in
-#'    the original data. default is `NULL`.
+#' @param keep A vector of column names to keep as-is. Default is `NULL`.
 #'
 #' @return the a list with 2 elements: input data frame with a knit column names
 #'          and the report object
 #' @keywords internal
 #' @noRd
 #'
-clean_col_names <- function(x, report = list(), keep_col_names = NULL) {
+clean_col_names <- function(x, report = list(), keep = NULL) {
   original_names <- col_names <- colnames(x)
 
   # in case the user wants to keep some column names as they are,
-  # they should be provided as value for the keep_col_names arguments.
+  # they should be provided as value for the keep arguments.
   # here we will make sure to spare those column names from been modified
 
   # check if the column names to be kept exist
-  if (!is.null(keep_col_names)) {
-    stopifnot("\nIncorrect column names were provided: " =
-                all(keep_col_names %in% original_names))
+  if (!is.null(keep)) {
+    stopifnot(
+      "\nIncorrect column names were provided: " =
+        all(keep %in% original_names)
+    )
   }
 
   # get the indexes of the column names to not change
-  idx               <- match(keep_col_names, original_names)
+  idx <- match(keep, original_names)
 
   # We have opted for snake case in the column names. Thus, all camel cases will
   # be converted into snake cases.
   if (length(idx) > 0L) {
-    tmp_col_names   <- snakecase::to_snake_case(col_names[-idx])
-    cleaned_names   <- epitrix::clean_labels(tmp_col_names)
+    tmp_col_names <- snakecase::to_snake_case(col_names[-idx])
+    cleaned_names <- epitrix::clean_labels(tmp_col_names)
     # make column name unique
-    unique_names    <- make.unique(cleaned_names, sep = "_")
+    unique_names <- make.unique(cleaned_names, sep = "_")
     # update the column names
     col_names[-idx] <- unique_names
   } else {
-    col_names       <- snakecase::to_snake_case(col_names)
-    col_names       <- epitrix::clean_labels(col_names)
+    col_names <- snakecase::to_snake_case(col_names)
+    col_names <- epitrix::clean_labels(col_names)
     # make column name unique
-    col_names       <- make.unique(col_names, sep = "_")
+    col_names <- make.unique(col_names, sep = "_")
   }
 
   # detect modified column names from the previous command
-  original_name     <- new_name <- NULL
-  xx  <- as.data.frame(cbind(original_name = original_names,
-                             new_name      = col_names)) %>%
-    dplyr::mutate(original_name = as.character(original_name),
-                  new_name      = as.character(new_name))
+  original_name <- new_name <- NULL
+  xx <- as.data.frame(cbind(
+    original_name = original_names,
+    new_name = col_names
+  )) |>
+    dplyr::mutate(
+      original_name = as.character(original_name),
+      new_name = as.character(new_name)
+    )
   idx <- which(xx[["original_name"]] != xx[["new_name"]])
   if (length(idx) > 0L) {
     report[["modified_column_names"]] <- xx[idx, ]

--- a/R/clean_data.R
+++ b/R/clean_data.R
@@ -40,14 +40,15 @@
 #'   \item `prefix`: the prefix used in the subject IDs
 #'   \item `suffix`: the prefix used in the subject IDs
 #'   \item `range`: a vector with the range of numbers in the sample IDs
+#'   \item `range`: a vector with the range of numbers in the sample IDs
 #'   }
 #'
 #' @return a list of the following 2 elements:
 #'  \enumerate{
 #'    \item `data`: the cleaned data frame according to the user-specified
 #'          parameters
-#'    \item `report`: a list with the information about the effects of the
-#'          the cleaning steps
+#'    \item `keep_col_names`: a vector of column names to be kept as they appear
+#'          in the original data. default is `NULL`
 #'  }
 #' @export
 #'
@@ -66,6 +67,7 @@
 #'   data   = readRDS(system.file("extdata", "test_df.RDS",
 #'                                package = "cleanepi")),
 #'   params = list(
+#'     keep_col_names      = NULL,
 #'     remove_duplicates   = TRUE,
 #'     target_columns      = NULL,
 #'     replace_missing     = TRUE,
@@ -80,7 +82,8 @@
 #'     range               = c(1, 100)))
 #'
 clean_data <- function(data,
-                       params = list(remove_duplicates   = FALSE,
+                       params = list(keep_col_names      = NULL,
+                                     remove_duplicates   = FALSE,
                                      target_columns      = NULL,
                                      replace_missing     = TRUE,
                                      na_comes_as         = NULL,
@@ -98,11 +101,13 @@ clean_data <- function(data,
   report <- list()
   ## -----
   ## | we choose to use snake_cases for both variable and column names
-  ## | column names are cleaned based on {janitor} package
-  ## | TBD: make sure not clean user-specified columns names
+  ## | are cleaned based using {baser} and {epitrix} packages.
+  ## | Column names in 'keep_col_names' will not be modified.
   ## -----
   R.utils::cat("\ncleaning column names")
-  res    <- clean_col_names(data, report)
+  res    <- clean_col_names(x              = data,
+                            report         = report,
+                            keep_col_names = params[["keep_col_names"]])
   data   <- res[["data"]]
   report <- res[["report"]]
 

--- a/R/clean_data.R
+++ b/R/clean_data.R
@@ -107,7 +107,7 @@ clean_data <- function(data,
   R.utils::cat("\ncleaning column names")
   res    <- clean_col_names(x              = data,
                             report         = report,
-                            keep_col_names = params[["keep_col_names"]])
+                            keep = params[["keep_col_names"]])
   data   <- res[["data"]]
   report <- res[["report"]]
 

--- a/man/clean_data.Rd
+++ b/man/clean_data.Rd
@@ -6,10 +6,10 @@
 \usage{
 clean_data(
   data,
-  params = list(remove_duplicates = FALSE, target_columns = NULL, replace_missing = TRUE,
-    na_comes_as = NULL, check_timeframe = FALSE, timeframe = NULL, error_tolerance = 0.5,
-    subject_id_col_name = NULL, subject_id_format = NULL, prefix = "PS", suffix = "P2",
-    range = c(1L, 100L))
+  params = list(keep_col_names = NULL, remove_duplicates = FALSE, target_columns = NULL,
+    replace_missing = TRUE, na_comes_as = NULL, check_timeframe = FALSE, timeframe =
+    NULL, error_tolerance = 0.5, subject_id_col_name = NULL, subject_id_format = NULL,
+    prefix = "PS", suffix = "P2", range = c(1L, 100L))
 )
 }
 \arguments{
@@ -48,6 +48,7 @@ the subject IDs
 \item \code{prefix}: the prefix used in the subject IDs
 \item \code{suffix}: the prefix used in the subject IDs
 \item \code{range}: a vector with the range of numbers in the sample IDs
+\item \code{range}: a vector with the range of numbers in the sample IDs
 }}
 }
 \value{
@@ -55,8 +56,8 @@ a list of the following 2 elements:
 \enumerate{
 \item \code{data}: the cleaned data frame according to the user-specified
 parameters
-\item \code{report}: a list with the information about the effects of the
-the cleaning steps
+\item \code{keep_col_names}: a vector of column names to be kept as they appear
+in the original data. default is \code{NULL}
 }
 }
 \description{
@@ -81,6 +82,7 @@ cleaned_data <- clean_data(
   data   = readRDS(system.file("extdata", "test_df.RDS",
                                package = "cleanepi")),
   params = list(
+    keep_col_names      = NULL,
     remove_duplicates   = TRUE,
     target_columns      = NULL,
     replace_missing     = TRUE,

--- a/tests/testthat/test-clean.R
+++ b/tests/testthat/test-clean.R
@@ -1,3 +1,15 @@
-test_that("multiplication works", {
+test_that("clean_col_names() keeps names passed in `keep` as-is", {
+  x <- readRDS(
+    system.file("extdata", "test_df.RDS", package = "cleanepi")
+  )
+  keep <- "date.of.admission"
+  out <- clean_col_names(x, keep = keep)
 
+  expect_true(
+    out[["report"]][["modified_column_names"]][["new_name"]]
+    %in% colnames(out[["data"]])
+  )
+  expect_true(
+    keep %in% colnames(out[["data"]])
+  )
 })


### PR DESCRIPTION
PR to review changes made in `R/clean_col_names.R` and `R/clean_data.R` to address this issue.
