### PR TITLE
Improve calculate_age()

### DIFF
--- a/R/calcualte_age.R
+++ b/R/calcualte_age.R
@@ -6,9 +6,6 @@
 #' @param end_date An end date, the default is today's date.
 #' @param age_in A string that specifies whether to return the age in 'years',
 #'    'months', 'weeks' or 'days'. The default is in 'years'.
-#' @param na_strings A string that represents the missing values in the
-#'    date column of interest. This is only needed when the date column
-#'    contains missing values.
 #' @param age_column_name A string for the name of the new column to be used to
 #'    store the calculated age in the input data.frame.
 #' @param age_remainder_unit A string for the unit in which the remainder of the
@@ -27,6 +24,14 @@
 #' @export
 #'
 #' @examples
+#' data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
+#'
+#' # The 'dateOfBirth' column contains missing values recoded as "-99". let's
+#' # replace them with NA
+#' data <- replace_missing_values(data           = data,
+#'                                target_columns = "dateOfBirth",
+#'                                na_strings     = "-99")
+#'
 #' # calculate the age 'years' and return the remainder in 'months'
 #' age <- calculate_age(
 #'   data               = readRDS(system.file("extdata", "test_df.RDS",
@@ -34,8 +39,7 @@
 #'   target_column      = "dateOfBirth",
 #'   end_date           = Sys.Date(),
 #'   age_in             = "years",
-#'   age_remainder_unit = "months",
-#'   na_strings         = "-99"
+#'   age_remainder_unit = "months"
 #' )
 #'
 #' # calculate the age in 'months' and return the remainder in 'days'
@@ -45,23 +49,16 @@
 #'   target_column      = "dateOfBirth",
 #'   end_date           = Sys.Date(),
 #'   age_in             = "months",
-#'   age_remainder_unit = "days",
-#'   na_strings         = "-99"
+#'   age_remainder_unit = "days"
 #' )
 calculate_age <- function(data,
                           target_column      = NULL,
                           end_date           = Sys.Date(),
-                          age_in             = c(
-                            "years", "months", "weeks", "days"
-                          ),
-                          na_strings         = cleanepi::common_na_strings,
+                          age_in             = c("years", "months",
+                                                 "weeks", "days"),
                           age_column_name    = sprintf("age_in_%s", age_in),
                           age_remainder_unit = c("months", "weeks", "days")) {
   checkmate::assert_data_frame(data, null.ok = FALSE)
-  checkmate::assert_vector(na_strings,
-    null.ok = FALSE,
-    any.missing = FALSE, min.len = 1L
-  )
 
   # check age_in, multiple choices not allowed by default
   # changed to give visibility of choices in function call in docs
@@ -83,11 +80,6 @@ calculate_age <- function(data,
   age_remainder_unit <- match.arg(age_remainder_unit)
   # get age remainder column name
   age_remainder_colname <- sprintf("remainder_%s", age_remainder_unit)
-
-  # replace missing data characters with NA
-  data <- replace_missing_values(data,
-                                 target_column,
-                                 na_strings = na_strings)
 
   # standardize the input data if required
   # NOTE: define `else` case or check that target column is a `Date`

--- a/R/calcualte_age.R
+++ b/R/calcualte_age.R
@@ -10,37 +10,38 @@
 #'    date column of interest. This is only needed when the date column
 #'    contains missing values.
 #' @param age_column_name A string for the name of the age column added to
-#' `data`.
+#'    the input data.
 #' @param age_remainder_unit A string for the unit in which the remainder of the
-#' age should be calculated. May be one of "months", "weeks", and "days".
-#' Remainders requested in the same unit as the age will return values of 0.
+#'    age should be calculated. May be one of "months", "weeks", and "days".
+#'    Remainders requested in the same unit as the age will return values of 0.
 #'
 #' @return The input data frame with 2 additional columns:
 #' \enumerate{
 #'   \item "age_in_years",  "age_in_months",  "age_in_weeks", or
 #'         "age_in_days" depending on the value of the 'age_in' parameter.
-#'   \item "remainder_days": A column with the number of remaining days after
-#'         the age is calculated in years, weeks or months.
+#'   \item "remainder_*": A column with the number of the remaining
+#'         days (remainder_days) or weeks (remainder_weeks) or months
+#'         (remainder_months) depending on the value of the 'age_remainder_unit'
+#'         parameter.
 #'   }
 #' @export
 #'
 #' @examples
 #' age <- calculate_age(
-#'   data = readRDS(system.file("extdata", "test_df.RDS",
-#'     package = "cleanepi"
-#'   )),
-#'   target_column = "dateOfBirth",
-#'   end_date = Sys.Date(),
-#'   age_in = "months",
+#'   data               = readRDS(system.file("extdata", "test_df.RDS",
+#'                                            package = "cleanepi")),
+#'   target_column      = "dateOfBirth",
+#'   end_date           = Sys.Date(),
+#'   age_in             = "months",
 #'   age_remainder_unit = "days",
-#'   na_strings = "-99"
+#'   na_strings         = "-99"
 #' )
 calculate_age <- function(data,
-                          target_column = NULL,
-                          end_date = Sys.Date(),
-                          age_in = "years",
-                          na_strings = common_na_strings,
-                          age_column_name = sprintf("age_in_%s", age_in),
+                          target_column      = NULL,
+                          end_date           = Sys.Date(),
+                          age_in             = "years",
+                          na_strings         = cleanepi::common_na_strings,
+                          age_column_name    = sprintf("age_in_%s", age_in),
                           age_remainder_unit = c("days", "weeks", "months")) {
   checkmate::assert_data_frame(data, null.ok = FALSE)
   checkmate::assert_vector(na_strings,
@@ -59,8 +60,6 @@ calculate_age <- function(data,
     as.Date(end_date),
     any.missing = FALSE, len = 1L, null.ok = TRUE
   )
-
-  # check age column name
   checkmate::assert_string(age_column_name)
 
   # check age remainder and match to options
@@ -71,41 +70,41 @@ calculate_age <- function(data,
   age_remainder_colname <- sprintf("remainder_%s", age_remainder_unit)
 
   # replace missing data characters with NA
-  data <- replace_missing_values(data, target_column,
-    na_strings = na_strings
-  )
+  data <- replace_missing_values(data,
+                                 target_column,
+                                 na_strings = na_strings)
 
   # standardize the input data if required
   # NOTE: define `else` case or check that target column is a `Date`
   if (!lubridate::is.Date(data[[target_column]])) {
     # the error_tolerance = 0.0 because target_column is explicit
-    data <- standardize_dates(data, target_column,
-      format          = NULL,
-      timeframe       = NULL,
-      error_tolerance = 0.0
-    )
+    data <- standardize_dates(data,
+                              target_column,
+                              format          = NULL,
+                              timeframe       = NULL,
+                              error_tolerance = 0.0)
   }
 
   # switch divisor based on requested unit
   # NOTE: no default case defined, add a default case?
   divisor_age <- switch(age_in,
-    years = lubridate::years(1L),
+    years  = lubridate::years(1L),
     months = months(1L), # from base
-    weeks = lubridate::weeks(1L),
-    days = lubridate::days(1) # not really necessary as difftime will be in days
+    weeks  = lubridate::weeks(1L),
+    days   = lubridate::days(1) # not really necessary(difftime will be in days)
   )
 
   # switch divisor for remainder based on requested unit
   divisor_remainder <- switch(age_remainder_unit,
     months = months(1L), # from base
-    weeks = lubridate::weeks(1L),
-    days = lubridate::days(1)
+    weeks  = lubridate::weeks(1L),
+    days   = lubridate::days(1)
   )
 
   # calculate the time difference, convert to a period, and get the quotient
   # and remainder
-  time_diff <- lubridate::as.period(end_date - data[[target_column]])
-  data[, age_column_name] <- time_diff %/% divisor_age
+  time_diff            <- lubridate::as.period(end_date - data[[target_column]])
+  data[, age_column_name]       <- time_diff %/% divisor_age
   data[, age_remainder_colname] <- (time_diff %% divisor_age) %/%
     divisor_remainder
 

--- a/R/calcualte_age.R
+++ b/R/calcualte_age.R
@@ -9,8 +9,8 @@
 #' @param na_strings A string that represents the missing values in the
 #'    date column of interest. This is only needed when the date column
 #'    contains missing values.
-#' @param age_column_name A string for the name of the age column added to
-#'    the input data.
+#' @param age_column_name A string for the name of the new column to be used to
+#'    store the calculated age in the input data.frame.
 #' @param age_remainder_unit A string for the unit in which the remainder of the
 #'    age should be calculated. May be one of "months", "weeks", and "days".
 #'    Remainders requested in the same unit as the age will return values of 0.
@@ -27,6 +27,18 @@
 #' @export
 #'
 #' @examples
+#' # calculate the age 'years' and return the remainder in 'months'
+#' age <- calculate_age(
+#'   data               = readRDS(system.file("extdata", "test_df.RDS",
+#'                                            package = "cleanepi")),
+#'   target_column      = "dateOfBirth",
+#'   end_date           = Sys.Date(),
+#'   age_in             = "years",
+#'   age_remainder_unit = "months",
+#'   na_strings         = "-99"
+#' )
+#'
+#' # calculate the age in 'months' and return the remainder in 'days'
 #' age <- calculate_age(
 #'   data               = readRDS(system.file("extdata", "test_df.RDS",
 #'                                            package = "cleanepi")),

--- a/R/calcualte_age.R
+++ b/R/calcualte_age.R
@@ -40,7 +40,7 @@ calculate_age <- function(data,
                           end_date = Sys.Date(),
                           age_in = "years",
                           na_strings = common_na_strings,
-                          age_column_name = sprintf("age_%s", age_in),
+                          age_column_name = sprintf("age_in_%s", age_in),
                           age_remainder_unit = c("days", "weeks", "months")) {
   checkmate::assert_data_frame(data, null.ok = FALSE)
   checkmate::assert_vector(na_strings,
@@ -108,6 +108,11 @@ calculate_age <- function(data,
   data[, age_column_name] <- time_diff %/% divisor_age
   data[, age_remainder_colname] <- (time_diff %% divisor_age) %/%
     divisor_remainder
+
+  # when the age is requested in days, remove remainder
+  if (age_in == "days") {
+    data[, age_remainder_colname] <- NULL
+  }
 
   return(data)
 }

--- a/R/calcualte_age.R
+++ b/R/calcualte_age.R
@@ -63,10 +63,9 @@ calculate_age <- function(data,
   # check age column name
   checkmate::assert_string(age_column_name)
 
-  # check age remainder unit string and match to options
+  # check age remainder and match to options
   # NOTE: "year" is not an option, but a remainder in "weeks" could be specified
   # for `age_in = "weeks"` - expect user will make common sense decisions
-  checkmate::assert_string(age_remainder_unit)
   age_remainder_unit <- match.arg(age_remainder_unit)
   # get age remainder column name
   age_remainder_colname <- sprintf("remainder_%s", age_remainder_unit)

--- a/R/calcualte_age.R
+++ b/R/calcualte_age.R
@@ -35,6 +35,12 @@
 #'                                target_columns = "dateOfBirth",
 #'                                na_strings     = "-99")
 #'
+#' # the calculate_age() function expects the date values to be given in ISO.
+#' # Let's convert the 'dateOfBirth' column into ISO date
+#' data <- standardize_dates(data            = data,
+#'                           target_columns  = "dateOfBirth",
+#'                           error_tolerance = 0.0)
+#'
 #' # calculate the age 'years' and return the remainder in 'months'
 #' age <- calculate_age(
 #'   data               = data,
@@ -44,14 +50,18 @@
 #'   age_remainder_unit = "months"
 #' )
 #'
-#' # calculate the age in 'months' and return the remainder in 'days'
-#' age <- calculate_age(
-#'   data               = data,
-#'   target_column      = "dateOfBirth",
-#'   end_date           = Sys.Date(),
-#'   age_in             = "months",
-#'   age_remainder_unit = "days"
-#' )
+#' # The operations above can be written in a pipe-formatted way:
+#' data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
+#' age  <- data |>
+#'   replace_missing_values(target_columns = "dateOfBirth",
+#'                          na_strings     = "-99") |>
+#'   standardize_dates(target_columns  = "dateOfBirth",
+#'                     error_tolerance = 0.0) |>
+#'   calculate_age(target_column      = "dateOfBirth",
+#'                 end_date           = Sys.Date(),
+#'                 age_in             = "years",
+#'                 age_remainder_unit = "months")
+#'
 calculate_age <- function(data,
                           target_column      = NULL,
                           end_date           = Sys.Date(),
@@ -81,17 +91,6 @@ calculate_age <- function(data,
   age_remainder_unit <- match.arg(age_remainder_unit)
   # get age remainder column name
   age_remainder_colname <- sprintf("remainder_%s", age_remainder_unit)
-
-  # standardize the input data if required
-  # NOTE: define `else` case or check that target column is a `Date`
-  if (!lubridate::is.Date(data[[target_column]])) {
-    # the error_tolerance = 0.0 because target_column is explicit
-    data <- standardize_dates(data,
-                              target_column,
-                              format          = NULL,
-                              timeframe       = NULL,
-                              error_tolerance = 0.0)
-  }
 
   # switch divisor based on requested unit
   # NOTE: no default case defined, add a default case?

--- a/R/calcualte_age.R
+++ b/R/calcualte_age.R
@@ -34,8 +34,7 @@
 #'
 #' # calculate the age 'years' and return the remainder in 'months'
 #' age <- calculate_age(
-#'   data               = readRDS(system.file("extdata", "test_df.RDS",
-#'                                            package = "cleanepi")),
+#'   data               = data,
 #'   target_column      = "dateOfBirth",
 #'   end_date           = Sys.Date(),
 #'   age_in             = "years",
@@ -44,8 +43,7 @@
 #'
 #' # calculate the age in 'months' and return the remainder in 'days'
 #' age <- calculate_age(
-#'   data               = readRDS(system.file("extdata", "test_df.RDS",
-#'                                            package = "cleanepi")),
+#'   data               = data,
 #'   target_column      = "dateOfBirth",
 #'   end_date           = Sys.Date(),
 #'   age_in             = "months",

--- a/R/calcualte_age.R
+++ b/R/calcualte_age.R
@@ -9,6 +9,11 @@
 #' @param na_strings A string that represents the missing values in the
 #'    date column of interest. This is only needed when the date column
 #'    contains missing values.
+#' @param age_column_name A string for the name of the age column added to
+#' `data`.
+#' @param age_remainder_unit A string for the unit in which the remainder of the
+#' age should be calculated. May be one of "months", "weeks", and "days".
+#' Remainders requested in the same unit as the age will return values of 0.
 #'
 #' @return The input data frame with 2 additional columns:
 #' \enumerate{
@@ -21,78 +26,89 @@
 #'
 #' @examples
 #' age <- calculate_age(
-#'   data          = readRDS(system.file("extdata", "test_df.RDS",
-#'                                       package = "cleanepi")),
+#'   data = readRDS(system.file("extdata", "test_df.RDS",
+#'     package = "cleanepi"
+#'   )),
 #'   target_column = "dateOfBirth",
-#'   end_date      = Sys.Date(),
-#'   age_in        = "months",
-#'   na_strings    = "-99"
+#'   end_date = Sys.Date(),
+#'   age_in = "months",
+#'   age_remainder_unit = "days",
+#'   na_strings = "-99"
 #' )
 calculate_age <- function(data,
                           target_column = NULL,
-                          end_date      = Sys.Date(),
-                          age_in        = "years",
-                          na_strings    = cleanepi::common_na_strings) {
+                          end_date = Sys.Date(),
+                          age_in = "years",
+                          na_strings = common_na_strings,
+                          age_column_name = sprintf("age_%s", age_in),
+                          age_remainder_unit = c("days", "weeks", "months")) {
   checkmate::assert_data_frame(data, null.ok = FALSE)
-  checkmate::assert_vector(na_strings, null.ok = FALSE,
-                           any.missing = FALSE, min.len = 1L)
+  checkmate::assert_vector(na_strings,
+    null.ok = FALSE,
+    any.missing = FALSE, min.len = 1L
+  )
   checkmate::assert_choice(age_in,
-                           choices = c("years", "months", "weeks", "days"),
-                           null.ok = FALSE)
-  checkmate::assert_choice(target_column, choices = colnames(data),
-                           null.ok = TRUE)
-  end_date <- checkmate::assert_date(as.Date(end_date),
-                                     any.missing = FALSE, len = 1L,
-                                     null.ok = TRUE)
-  tmp_age <- remainder_days <- NULL
+    choices = c("years", "months", "weeks", "days"),
+    null.ok = FALSE
+  )
+  checkmate::assert_choice(target_column,
+    choices = colnames(data),
+    null.ok = TRUE
+  )
+  end_date <- checkmate::assert_date(
+    as.Date(end_date),
+    any.missing = FALSE, len = 1L, null.ok = TRUE
+  )
+
+  # check age column name
+  checkmate::assert_string(age_column_name)
+
+  # check age remainder unit string and match to options
+  # NOTE: "year" is not an option, but a remainder in "weeks" could be specified
+  # for `age_in = "weeks"` - expect user will make common sense decisions
+  checkmate::assert_string(age_remainder_unit)
+  age_remainder_unit <- match.arg(age_remainder_unit)
+  # get age remainder column name
+  age_remainder_colname <- sprintf("remainder_%s", age_remainder_unit)
 
   # replace missing data characters with NA
   data <- replace_missing_values(data, target_column,
-                                 na_strings = na_strings)
+    na_strings = na_strings
+  )
 
   # standardize the input data if required
+  # NOTE: define `else` case or check that target column is a `Date`
   if (!lubridate::is.Date(data[[target_column]])) {
     # the error_tolerance = 0.0 because target_column is explicit
     data <- standardize_dates(data, target_column,
-                              format          = NULL,
-                              timeframe       = NULL,
-                              error_tolerance = 0.0)
+      format          = NULL,
+      timeframe       = NULL,
+      error_tolerance = 0.0
+    )
   }
 
-  # calculate the age
-  res <- switch(age_in,
-    years = data %>%
-      dplyr::mutate(age_years = round((data[[target_column]] %--% end_date)
-      %/% lubridate::years(1L))),
-    months = data %>%
-      dplyr::mutate(tmp_age = lubridate::as.period(end_date -
-                                                     data[[target_column]])) %>%
-      dplyr::mutate(
-        age_months = tmp_age %/% months(1L, abbreviate = FALSE),
-        remainder_days = (tmp_age %% months(1L, abbreviate = FALSE)) %/%
-          lubridate::days(1L)
-      ) %>%
-      dplyr::select(-tmp_age),
-    days = data %>%
-      dplyr::mutate(tmp_age = lubridate::as.period(end_date -
-                                                     data[[target_column]])) %>%
-      dplyr::mutate(
-        age_days = tmp_age %/% lubridate::days(1L)
-      ) %>%
-      dplyr::select(-tmp_age),
-    weeks = data %>%
-      dplyr::mutate(tmp_age = lubridate::as.period(end_date -
-                                                     data[[target_column]])) %>%
-      dplyr::mutate(
-        age_weeks = tmp_age %/% lubridate::weeks(1L),
-        remainder_days = (tmp_age %% lubridate::weeks(1L))
-        %/% lubridate::days(1L)
-      ) %>%
-      dplyr::select(-tmp_age)
+  # switch divisor based on requested unit
+  # NOTE: no default case defined, add a default case?
+  divisor_age <- switch(age_in,
+    years = lubridate::years(1L),
+    months = months(1L), # from base
+    weeks = lubridate::weeks(1L),
+    days = lubridate::days(1) # not really necessary as difftime will be in days
   )
-  if (age_in %in% c("months", "weeks") && all(res[["remainder_days"]] == 0L)) {
-    res <- res %>% dplyr::select(-remainder_days)
-  }
 
-  return(res)
+  # switch divisor for remainder based on requested unit
+  divisor_remainder <- switch(age_remainder_unit,
+    months = months(1L), # from base
+    weeks = lubridate::weeks(1L),
+    days = lubridate::days(1)
+  )
+
+  # calculate the time difference, convert to a period, and get the quotient
+  # and remainder
+  time_diff <- lubridate::as.period(end_date - data[[target_column]])
+  data[, age_column_name] <- time_diff %/% divisor_age
+  data[, age_remainder_colname] <- (time_diff %% divisor_age) %/%
+    divisor_remainder
+
+  return(data)
 }

--- a/R/calcualte_age.R
+++ b/R/calcualte_age.R
@@ -39,25 +39,28 @@
 calculate_age <- function(data,
                           target_column      = NULL,
                           end_date           = Sys.Date(),
-                          age_in             = "years",
+                          age_in             = c(
+                            "years", "months", "weeks", "days"
+                          ),
                           na_strings         = cleanepi::common_na_strings,
                           age_column_name    = sprintf("age_in_%s", age_in),
-                          age_remainder_unit = c("days", "weeks", "months")) {
+                          age_remainder_unit = c("months", "weeks", "days")) {
   checkmate::assert_data_frame(data, null.ok = FALSE)
   checkmate::assert_vector(na_strings,
     null.ok = FALSE,
     any.missing = FALSE, min.len = 1L
   )
-  checkmate::assert_choice(age_in,
-    choices = c("years", "months", "weeks", "days"),
-    null.ok = FALSE
-  )
+
+  # check age_in, multiple choices not allowed by default
+  # changed to give visibility of choices in function call in docs
+  age_in <- match.arg(age_in)
+
   checkmate::assert_choice(target_column,
     choices = colnames(data),
     null.ok = TRUE
   )
   end_date <- checkmate::assert_date(
-    as.Date(end_date),
+    end_date,
     any.missing = FALSE, len = 1L, null.ok = TRUE
   )
   checkmate::assert_string(age_column_name)
@@ -89,14 +92,14 @@ calculate_age <- function(data,
   # NOTE: no default case defined, add a default case?
   divisor_age <- switch(age_in,
     years  = lubridate::years(1L),
-    months = months(1L), # from base
+    months = months(1L), # from base, lubridate provides method returning period
     weeks  = lubridate::weeks(1L),
     days   = lubridate::days(1) # not really necessary(difftime will be in days)
   )
 
   # switch divisor for remainder based on requested unit
   divisor_remainder <- switch(age_remainder_unit,
-    months = months(1L), # from base
+    months = months(1L), # from base as above
     weeks  = lubridate::weeks(1L),
     days   = lubridate::days(1)
   )

--- a/R/calcualte_age.R
+++ b/R/calcualte_age.R
@@ -3,7 +3,10 @@
 #' @param data A data frame with at least one date column.
 #' @param target_column A string specifying the name of the date column of
 #'    interest.
-#' @param end_date An end date, the default is today's date.
+#' @param end_date An end date. This should be in the format
+#'    `%Y-%m-%d` ("2024-12-31" for 31st of December 2024). Otherwise, use the
+#'    `as.Date()` function and specify the format of the end date. The default
+#'    is today's date `Sys.Date()`.
 #' @param age_in A string that specifies whether to return the age in 'years',
 #'    'months', 'weeks' or 'days'. The default is in 'years'.
 #' @param age_column_name A string for the name of the new column to be used to

--- a/R/replace_missing_values.R
+++ b/R/replace_missing_values.R
@@ -18,8 +18,8 @@
 #'
 #' @examples
 #' cleaned_data <- replace_missing_values(
-#'   data        = readRDS(system.file("extdata", "test_df.RDS",
-#'                                     package = "cleanepi")),
+#'   data           = readRDS(system.file("extdata", "test_df.RDS",
+#'                                        package = "cleanepi")),
 #'   target_columns = "sex",
 #'   na_strings     = "-99"
 #' )
@@ -31,23 +31,24 @@ replace_missing_values <- function(data,
   cols    <- get_target_column_names(data, target_columns, cols = NULL)
 
   # replace missing values with NA
-  res     <- 0L
   indexes <- NULL
+  res     <- 0L
   for (col in cols) {
     index              <- match(col, names(data))
     names(data)[index] <- "x"
-    idx                <- which(na_strings %in% data[["x"]])
-    if (length(idx) > 0L) {
-      data             <- naniar::replace_with_na(
-        data,
-        replace = list(x = na_strings[idx])
-      )
-      indexes          <- c(indexes, col)
-    } else {
-      res              <- res + 1L
+    idx                <- match(na_strings, data[["x"]])
+    if (all(is.na(idx))) {
+      res                <- res + 1L
+      names(data)[index] <- col
+      next
     }
+    idx     <- which(na_strings %in% data[["x"]])
+    data    <- naniar::replace_with_na(data,
+                                       replace = list(x = na_strings[idx]))
+    indexes <- c(indexes, col)
     names(data)[index] <- col
   }
+
   stopifnot("Could not detect missing value character! Please use the
   appropriate strings that represents the missing values from your data." =
               res < length(cols))

--- a/R/replace_missing_values.R
+++ b/R/replace_missing_values.R
@@ -3,10 +3,16 @@
 #'
 #' @param data A data frame or linelist
 #' @param target_columns A vector of column names. If provided, the substitution
+<<<<<<< HEAD
 #'    of missing values will only be executed in those specified columns.
 #'    When the input data is a `linelist` object, this parameter can be set to
 #'    `linelist_tags` if you wish to replace missing values across tagged
 #'    columns only.
+=======
+#'    of missing values will only be executed in those specified columns. When
+#'    the input data is a `linelist` object, this parameter can be set to `tags`
+#'    if you wish to replace missing values with NA on tagged columns only.
+>>>>>>> aa32a41 (allow for target_columns = "linelist_tags")
 #' @param na_strings This is a vector of strings that represents the missing
 #'    values in the columns of interest. By default, it utilizes
 #'    `cleanepi::common_na_strings`. However, if the missing values string in

--- a/R/replace_missing_values.R
+++ b/R/replace_missing_values.R
@@ -3,16 +3,10 @@
 #'
 #' @param data A data frame or linelist
 #' @param target_columns A vector of column names. If provided, the substitution
-<<<<<<< HEAD
 #'    of missing values will only be executed in those specified columns.
 #'    When the input data is a `linelist` object, this parameter can be set to
 #'    `linelist_tags` if you wish to replace missing values across tagged
 #'    columns only.
-=======
-#'    of missing values will only be executed in those specified columns. When
-#'    the input data is a `linelist` object, this parameter can be set to `tags`
-#'    if you wish to replace missing values with NA on tagged columns only.
->>>>>>> aa32a41 (allow for target_columns = "linelist_tags")
 #' @param na_strings This is a vector of strings that represents the missing
 #'    values in the columns of interest. By default, it utilizes
 #'    `cleanepi::common_na_strings`. However, if the missing values string in

--- a/R/replace_missing_values.R
+++ b/R/replace_missing_values.R
@@ -3,9 +3,9 @@
 #'
 #' @param data A data frame or linelist
 #' @param target_columns A vector of column names. If provided, the substitution
-#'    of missing values will only be executed in those specified columns.
-#'    When the input data is a `linelist` object, this parameter can be set to
-#'    `linelist_tags` if you wish to replace missing values across tagged
+#'    of missing values will only be executed in those specified columns. When
+#'    the input data is a `linelist` object, this parameter can be set to
+#'    `linelist_tags` if you wish to replace missing values with NA on tagged
 #'    columns only.
 #' @param na_strings This is a vector of strings that represents the missing
 #'    values in the columns of interest. By default, it utilizes

--- a/man/calculate_age.Rd
+++ b/man/calculate_age.Rd
@@ -19,7 +19,10 @@ calculate_age(
 \item{target_column}{A string specifying the name of the date column of
 interest.}
 
-\item{end_date}{An end date, the default is today's date.}
+\item{end_date}{An end date. This should be in the format
+\verb{\%Y-\%m-\%d} ("2024-12-31" for 31st of December 2024). Otherwise, use the
+\code{as.Date()} function and specify the format of the end date. The default
+is today's date \code{Sys.Date()}.}
 
 \item{age_in}{A string that specifies whether to return the age in 'years',
 'months', 'weeks' or 'days'. The default is in 'years'.}

--- a/man/calculate_age.Rd
+++ b/man/calculate_age.Rd
@@ -9,7 +9,7 @@ calculate_age(
   target_column = NULL,
   end_date = Sys.Date(),
   age_in = "years",
-  na_strings = common_na_strings,
+  na_strings = cleanepi::common_na_strings,
   age_column_name = sprintf("age_in_\%s", age_in),
   age_remainder_unit = c("days", "weeks", "months")
 )
@@ -30,7 +30,7 @@ date column of interest. This is only needed when the date column
 contains missing values.}
 
 \item{age_column_name}{A string for the name of the age column added to
-\code{data}.}
+the input data.}
 
 \item{age_remainder_unit}{A string for the unit in which the remainder of the
 age should be calculated. May be one of "months", "weeks", and "days".
@@ -41,8 +41,10 @@ The input data frame with 2 additional columns:
 \enumerate{
 \item "age_in_years",  "age_in_months",  "age_in_weeks", or
 "age_in_days" depending on the value of the 'age_in' parameter.
-\item "remainder_days": A column with the number of remaining days after
-the age is calculated in years, weeks or months.
+\item "remainder_*": A column with the number of the remaining
+days (remainder_days) or weeks (remainder_weeks) or months
+(remainder_months) depending on the value of the 'age_remainder_unit'
+parameter.
 }
 }
 \description{
@@ -50,13 +52,12 @@ Calculate age from a specified date column
 }
 \examples{
 age <- calculate_age(
-  data = readRDS(system.file("extdata", "test_df.RDS",
-    package = "cleanepi"
-  )),
-  target_column = "dateOfBirth",
-  end_date = Sys.Date(),
-  age_in = "months",
+  data               = readRDS(system.file("extdata", "test_df.RDS",
+                                           package = "cleanepi")),
+  target_column      = "dateOfBirth",
+  end_date           = Sys.Date(),
+  age_in             = "months",
   age_remainder_unit = "days",
-  na_strings = "-99"
+  na_strings         = "-99"
 )
 }

--- a/man/calculate_age.Rd
+++ b/man/calculate_age.Rd
@@ -57,6 +57,12 @@ data <- replace_missing_values(data           = data,
                                target_columns = "dateOfBirth",
                                na_strings     = "-99")
 
+# the calculate_age() function expects the date values to be given in ISO.
+# Let's convert the 'dateOfBirth' column into ISO date
+data <- standardize_dates(data            = data,
+                          target_columns  = "dateOfBirth",
+                          error_tolerance = 0.0)
+
 # calculate the age 'years' and return the remainder in 'months'
 age <- calculate_age(
   data               = data,
@@ -66,12 +72,16 @@ age <- calculate_age(
   age_remainder_unit = "months"
 )
 
-# calculate the age in 'months' and return the remainder in 'days'
-age <- calculate_age(
-  data               = data,
-  target_column      = "dateOfBirth",
-  end_date           = Sys.Date(),
-  age_in             = "months",
-  age_remainder_unit = "days"
-)
+# The operations above can be written in a pipe-formatted way:
+data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
+age  <- data |>
+  replace_missing_values(target_columns = "dateOfBirth",
+                         na_strings     = "-99") |>
+  standardize_dates(target_columns  = "dateOfBirth",
+                    error_tolerance = 0.0) |>
+  calculate_age(target_column      = "dateOfBirth",
+                end_date           = Sys.Date(),
+                age_in             = "years",
+                age_remainder_unit = "months")
+
 }

--- a/man/calculate_age.Rd
+++ b/man/calculate_age.Rd
@@ -9,7 +9,6 @@ calculate_age(
   target_column = NULL,
   end_date = Sys.Date(),
   age_in = c("years", "months", "weeks", "days"),
-  na_strings = cleanepi::common_na_strings,
   age_column_name = sprintf("age_in_\%s", age_in),
   age_remainder_unit = c("months", "weeks", "days")
 )
@@ -25,12 +24,8 @@ interest.}
 \item{age_in}{A string that specifies whether to return the age in 'years',
 'months', 'weeks' or 'days'. The default is in 'years'.}
 
-\item{na_strings}{A string that represents the missing values in the
-date column of interest. This is only needed when the date column
-contains missing values.}
-
-\item{age_column_name}{A string for the name of the age column added to
-the input data.}
+\item{age_column_name}{A string for the name of the new column to be used to
+store the calculated age in the input data.frame.}
 
 \item{age_remainder_unit}{A string for the unit in which the remainder of the
 age should be calculated. May be one of "months", "weeks", and "days".
@@ -51,13 +46,31 @@ parameter.
 Calculate age from a specified date column
 }
 \examples{
+data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
+
+# The 'dateOfBirth' column contains missing values recoded as "-99". let's
+# replace them with NA
+data <- replace_missing_values(data           = data,
+                               target_columns = "dateOfBirth",
+                               na_strings     = "-99")
+
+# calculate the age 'years' and return the remainder in 'months'
+age <- calculate_age(
+  data               = readRDS(system.file("extdata", "test_df.RDS",
+                                           package = "cleanepi")),
+  target_column      = "dateOfBirth",
+  end_date           = Sys.Date(),
+  age_in             = "years",
+  age_remainder_unit = "months"
+)
+
+# calculate the age in 'months' and return the remainder in 'days'
 age <- calculate_age(
   data               = readRDS(system.file("extdata", "test_df.RDS",
                                            package = "cleanepi")),
   target_column      = "dateOfBirth",
   end_date           = Sys.Date(),
   age_in             = "months",
-  age_remainder_unit = "days",
-  na_strings         = "-99"
+  age_remainder_unit = "days"
 )
 }

--- a/man/calculate_age.Rd
+++ b/man/calculate_age.Rd
@@ -56,8 +56,7 @@ data <- replace_missing_values(data           = data,
 
 # calculate the age 'years' and return the remainder in 'months'
 age <- calculate_age(
-  data               = readRDS(system.file("extdata", "test_df.RDS",
-                                           package = "cleanepi")),
+  data               = data,
   target_column      = "dateOfBirth",
   end_date           = Sys.Date(),
   age_in             = "years",
@@ -66,8 +65,7 @@ age <- calculate_age(
 
 # calculate the age in 'months' and return the remainder in 'days'
 age <- calculate_age(
-  data               = readRDS(system.file("extdata", "test_df.RDS",
-                                           package = "cleanepi")),
+  data               = data,
   target_column      = "dateOfBirth",
   end_date           = Sys.Date(),
   age_in             = "months",

--- a/man/calculate_age.Rd
+++ b/man/calculate_age.Rd
@@ -9,7 +9,9 @@ calculate_age(
   target_column = NULL,
   end_date = Sys.Date(),
   age_in = "years",
-  na_strings = cleanepi::common_na_strings
+  na_strings = common_na_strings,
+  age_column_name = sprintf("age_\%s", age_in),
+  age_remainder_unit = c("days", "weeks", "months")
 )
 }
 \arguments{
@@ -26,6 +28,13 @@ interest.}
 \item{na_strings}{A string that represents the missing values in the
 date column of interest. This is only needed when the date column
 contains missing values.}
+
+\item{age_column_name}{A string for the name of the age column added to
+\code{data}.}
+
+\item{age_remainder_unit}{A string for the unit in which the remainder of the
+age should be calculated. May be one of "months", "weeks", and "days".
+Remainders requested in the same unit as the age will return values of 0.}
 }
 \value{
 The input data frame with 2 additional columns:
@@ -41,11 +50,13 @@ Calculate age from a specified date column
 }
 \examples{
 age <- calculate_age(
-  data          = readRDS(system.file("extdata", "test_df.RDS",
-                                      package = "cleanepi")),
+  data = readRDS(system.file("extdata", "test_df.RDS",
+    package = "cleanepi"
+  )),
   target_column = "dateOfBirth",
-  end_date      = Sys.Date(),
-  age_in        = "months",
-  na_strings    = "-99"
+  end_date = Sys.Date(),
+  age_in = "months",
+  age_remainder_unit = "days",
+  na_strings = "-99"
 )
 }

--- a/man/calculate_age.Rd
+++ b/man/calculate_age.Rd
@@ -10,7 +10,7 @@ calculate_age(
   end_date = Sys.Date(),
   age_in = "years",
   na_strings = common_na_strings,
-  age_column_name = sprintf("age_\%s", age_in),
+  age_column_name = sprintf("age_in_\%s", age_in),
   age_remainder_unit = c("days", "weeks", "months")
 )
 }

--- a/man/calculate_age.Rd
+++ b/man/calculate_age.Rd
@@ -8,10 +8,10 @@ calculate_age(
   data,
   target_column = NULL,
   end_date = Sys.Date(),
-  age_in = "years",
+  age_in = c("years", "months", "weeks", "days"),
   na_strings = cleanepi::common_na_strings,
   age_column_name = sprintf("age_in_\%s", age_in),
-  age_remainder_unit = c("days", "weeks", "months")
+  age_remainder_unit = c("months", "weeks", "days")
 )
 }
 \arguments{

--- a/man/cleanepi-package.Rd
+++ b/man/cleanepi-package.Rd
@@ -6,7 +6,7 @@
 \alias{cleanepi-package}
 \title{cleanepi: Clean and Standardize Epidemiological Data}
 \description{
-cleanepi provides functions for cleaning and standardizing tabular data, tailored specifically for curating epidemiological data.
+Provides functions for cleaning and standardizing tabular data, tailored specifically for curating epidemiological data.
 }
 \seealso{
 Useful links:

--- a/man/replace_missing_values.Rd
+++ b/man/replace_missing_values.Rd
@@ -33,8 +33,8 @@ Replace missing values with \code{NA}
 }
 \examples{
 cleaned_data <- replace_missing_values(
-  data        = readRDS(system.file("extdata", "test_df.RDS",
-                                    package = "cleanepi")),
+  data           = readRDS(system.file("extdata", "test_df.RDS",
+                                       package = "cleanepi")),
   target_columns = "sex",
   na_strings     = "-99"
 )

--- a/man/replace_missing_values.Rd
+++ b/man/replace_missing_values.Rd
@@ -14,9 +14,9 @@ replace_missing_values(
 \item{data}{A data frame or linelist}
 
 \item{target_columns}{A vector of column names. If provided, the substitution
-of missing values will only be executed in those specified columns.
-When the input data is a \code{linelist} object, this parameter can be set to
-\code{linelist_tags} if you wish to replace missing values across tagged
+of missing values will only be executed in those specified columns. When
+the input data is a \code{linelist} object, this parameter can be set to
+\code{linelist_tags} if you wish to replace missing values with NA on tagged
 columns only.}
 
 \item{na_strings}{This is a vector of strings that represents the missing

--- a/tests/testthat/test-calculate_age.R
+++ b/tests/testthat/test-calculate_age.R
@@ -7,8 +7,7 @@ test_that("calculate_age works when age is calculated in months and
               target_column      = "dateOfBirth",
               end_date           = Sys.Date(),
               age_in             = "months",
-              age_remainder_unit = "days",
-              na_strings         = "-99"
+              age_remainder_unit = "days"
             )
             expect_s3_class(age, "data.frame")
             expect_identical(ncol(age), 10L)
@@ -23,8 +22,7 @@ test_that("calculate_age works when age is calculated in months and
               target_column      = "dateOfBirth",
               end_date           = Sys.Date(),
               age_in             = "months",
-              age_remainder_unit = "weeks",
-              na_strings         = "-99"
+              age_remainder_unit = "weeks"
             )
             expect_s3_class(age, "data.frame")
             expect_identical(ncol(age), 10L)
@@ -39,8 +37,7 @@ test_that("calculate_age works when age is calculated in years and
               target_column      = "dateOfBirth",
               end_date           = Sys.Date(),
               age_in             = "years",
-              age_remainder_unit = "months",
-              na_strings         = "-99"
+              age_remainder_unit = "months"
             )
             expect_s3_class(age, "data.frame")
             expect_identical(ncol(age), 10L)
@@ -55,8 +52,7 @@ test_that("calculate_age works when age is calculated in years and
               target_column      = "dateOfBirth",
               end_date           = Sys.Date(),
               age_in             = "years",
-              age_remainder_unit = "weeks",
-              na_strings         = "-99"
+              age_remainder_unit = "weeks"
             )
             expect_s3_class(age, "data.frame")
             expect_identical(ncol(age), 10L)
@@ -71,8 +67,7 @@ test_that("calculate_age works when age is calculated in years and
               target_column      = "dateOfBirth",
               end_date           = Sys.Date(),
               age_in             = "years",
-              age_remainder_unit = "days",
-              na_strings         = "-99"
+              age_remainder_unit = "days"
             )
             expect_s3_class(age, "data.frame")
             expect_identical(ncol(age), 10L)
@@ -85,8 +80,7 @@ test_that("calculate_age works when age is calculated in days", {
     data               = data,
     target_column      = "dateOfBirth",
     end_date           = Sys.Date(),
-    age_in             = "days",
-    na_strings         = "-99"
+    age_in             = "days"
   )
   expect_s3_class(age, "data.frame")
   expect_identical(ncol(age), 9L)

--- a/tests/testthat/test-calculate_age.R
+++ b/tests/testthat/test-calculate_age.R
@@ -1,4 +1,8 @@
-data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
+data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi")) |>
+  replace_missing_values(target_columns = "dateOfBirth",
+                         na_strings     = "-99") |>
+  standardize_dates(target_columns  = "dateOfBirth",
+                    error_tolerance = 0.0)
 
 test_that("calculate_age works when age is calculated in months and
           age_remainder_unit is days", {

--- a/tests/testthat/test-calculate_age.R
+++ b/tests/testthat/test-calculate_age.R
@@ -1,90 +1,86 @@
 data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
 
-test_that("calculate_age works", {
-  age <- calculate_age(
-    data               = data,
-    target_column      = "dateOfBirth",
-    end_date           = Sys.Date(),
-    age_in             = "months",
-    age_remainder_unit = "days",
-    na_strings         = "-99"
-  )
-  expect_s3_class(age, "data.frame")
-  expect_identical(ncol(age), 10L)
-  expect_identical(names(age)[9L:10L], c("age_in_months", "remainder_days"))
+test_that("calculate_age works when age is calculated in months and
+          age_remainder_unit is days", {
+            age <- calculate_age(
+              data               = data,
+              target_column      = "dateOfBirth",
+              end_date           = Sys.Date(),
+              age_in             = "months",
+              age_remainder_unit = "days",
+              na_strings         = "-99"
+            )
+            expect_s3_class(age, "data.frame")
+            expect_identical(ncol(age), 10L)
+            expect_identical(names(age)[9L:10L], c("age_in_months",
+                                                   "remainder_days"))
 })
 
-test_that("calculate_age works", {
-  age <- calculate_age(
-    data               = data,
-    target_column      = "dateOfBirth",
-    end_date           = Sys.Date(),
-    age_in             = "months",
-    age_remainder_unit = "weeks",
-    na_strings         = "-99"
-  )
-  expect_s3_class(age, "data.frame")
-  expect_identical(ncol(age), 10L)
-  expect_identical(names(age)[9L:10L], c("age_in_months", "remainder_weeks"))
+test_that("calculate_age works when age is calculated in months and
+          age_remainder_unit is weeks", {
+            age <- calculate_age(
+              data               = data,
+              target_column      = "dateOfBirth",
+              end_date           = Sys.Date(),
+              age_in             = "months",
+              age_remainder_unit = "weeks",
+              na_strings         = "-99"
+            )
+            expect_s3_class(age, "data.frame")
+            expect_identical(ncol(age), 10L)
+            expect_identical(names(age)[9L:10L], c("age_in_months",
+                                                   "remainder_weeks"))
 })
 
-test_that("calculate_age works", {
-  age <- calculate_age(
-    data               = data,
-    target_column      = "dateOfBirth",
-    end_date           = Sys.Date(),
-    age_in             = "months",
-    age_remainder_unit = "weeks",
-    na_strings         = "-99"
-  )
-  expect_s3_class(age, "data.frame")
-  expect_identical(ncol(age), 10L)
-  expect_identical(names(age)[9L:10L], c("age_in_months", "remainder_weeks"))
+test_that("calculate_age works when age is calculated in years and
+          age_remainder_unit is months", {
+            age <- calculate_age(
+              data               = data,
+              target_column      = "dateOfBirth",
+              end_date           = Sys.Date(),
+              age_in             = "years",
+              age_remainder_unit = "months",
+              na_strings         = "-99"
+            )
+            expect_s3_class(age, "data.frame")
+            expect_identical(ncol(age), 10L)
+            expect_identical(names(age)[9L:10L], c("age_in_years",
+                                                   "remainder_months"))
 })
 
-test_that("calculate_age works", {
-  age <- calculate_age(
-    data               = data,
-    target_column      = "dateOfBirth",
-    end_date           = Sys.Date(),
-    age_in             = "years",
-    age_remainder_unit = "months",
-    na_strings         = "-99"
-  )
-  expect_s3_class(age, "data.frame")
-  expect_identical(ncol(age), 10L)
-  expect_identical(names(age)[9L:10L], c("age_in_years", "remainder_months"))
+test_that("calculate_age works when age is calculated in years and
+          age_remainder_unit is weeks", {
+            age <- calculate_age(
+              data               = data,
+              target_column      = "dateOfBirth",
+              end_date           = Sys.Date(),
+              age_in             = "years",
+              age_remainder_unit = "weeks",
+              na_strings         = "-99"
+            )
+            expect_s3_class(age, "data.frame")
+            expect_identical(ncol(age), 10L)
+            expect_identical(names(age)[9L:10L], c("age_in_years",
+                                                   "remainder_weeks"))
 })
 
-test_that("calculate_age works", {
-  age <- calculate_age(
-    data               = data,
-    target_column      = "dateOfBirth",
-    end_date           = Sys.Date(),
-    age_in             = "years",
-    age_remainder_unit = "weeks",
-    na_strings         = "-99"
-  )
-  expect_s3_class(age, "data.frame")
-  expect_identical(ncol(age), 10L)
-  expect_identical(names(age)[9L:10L], c("age_in_years", "remainder_weeks"))
+test_that("calculate_age works when age is calculated in years and
+          age_remainder_unit is days", {
+            age <- calculate_age(
+              data               = data,
+              target_column      = "dateOfBirth",
+              end_date           = Sys.Date(),
+              age_in             = "years",
+              age_remainder_unit = "days",
+              na_strings         = "-99"
+            )
+            expect_s3_class(age, "data.frame")
+            expect_identical(ncol(age), 10L)
+            expect_identical(names(age)[9L:10L], c("age_in_years",
+                                                   "remainder_days"))
 })
 
-test_that("calculate_age works", {
-  age <- calculate_age(
-    data               = data,
-    target_column      = "dateOfBirth",
-    end_date           = Sys.Date(),
-    age_in             = "years",
-    age_remainder_unit = "days",
-    na_strings         = "-99"
-  )
-  expect_s3_class(age, "data.frame")
-  expect_identical(ncol(age), 10L)
-  expect_identical(names(age)[9L:10L], c("age_in_years", "remainder_days"))
-})
-
-test_that("calculate_age works", {
+test_that("calculate_age works when age is calculated in days", {
   age <- calculate_age(
     data               = data,
     target_column      = "dateOfBirth",

--- a/tests/testthat/test-calculate_age.R
+++ b/tests/testthat/test-calculate_age.R
@@ -1,0 +1,98 @@
+data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
+
+test_that("calculate_age works", {
+  age <- calculate_age(
+    data               = data,
+    target_column      = "dateOfBirth",
+    end_date           = Sys.Date(),
+    age_in             = "months",
+    age_remainder_unit = "days",
+    na_strings         = "-99"
+  )
+  expect_s3_class(age, "data.frame")
+  expect_identical(ncol(age), 10L)
+  expect_identical(names(age)[9L:10L], c("age_in_months", "remainder_days"))
+})
+
+test_that("calculate_age works", {
+  age <- calculate_age(
+    data               = data,
+    target_column      = "dateOfBirth",
+    end_date           = Sys.Date(),
+    age_in             = "months",
+    age_remainder_unit = "weeks",
+    na_strings         = "-99"
+  )
+  expect_s3_class(age, "data.frame")
+  expect_identical(ncol(age), 10L)
+  expect_identical(names(age)[9L:10L], c("age_in_months", "remainder_weeks"))
+})
+
+test_that("calculate_age works", {
+  age <- calculate_age(
+    data               = data,
+    target_column      = "dateOfBirth",
+    end_date           = Sys.Date(),
+    age_in             = "months",
+    age_remainder_unit = "weeks",
+    na_strings         = "-99"
+  )
+  expect_s3_class(age, "data.frame")
+  expect_identical(ncol(age), 10L)
+  expect_identical(names(age)[9L:10L], c("age_in_months", "remainder_weeks"))
+})
+
+test_that("calculate_age works", {
+  age <- calculate_age(
+    data               = data,
+    target_column      = "dateOfBirth",
+    end_date           = Sys.Date(),
+    age_in             = "years",
+    age_remainder_unit = "months",
+    na_strings         = "-99"
+  )
+  expect_s3_class(age, "data.frame")
+  expect_identical(ncol(age), 10L)
+  expect_identical(names(age)[9L:10L], c("age_in_years", "remainder_months"))
+})
+
+test_that("calculate_age works", {
+  age <- calculate_age(
+    data               = data,
+    target_column      = "dateOfBirth",
+    end_date           = Sys.Date(),
+    age_in             = "years",
+    age_remainder_unit = "weeks",
+    na_strings         = "-99"
+  )
+  expect_s3_class(age, "data.frame")
+  expect_identical(ncol(age), 10L)
+  expect_identical(names(age)[9L:10L], c("age_in_years", "remainder_weeks"))
+})
+
+test_that("calculate_age works", {
+  age <- calculate_age(
+    data               = data,
+    target_column      = "dateOfBirth",
+    end_date           = Sys.Date(),
+    age_in             = "years",
+    age_remainder_unit = "days",
+    na_strings         = "-99"
+  )
+  expect_s3_class(age, "data.frame")
+  expect_identical(ncol(age), 10L)
+  expect_identical(names(age)[9L:10L], c("age_in_years", "remainder_days"))
+})
+
+test_that("calculate_age works", {
+  age <- calculate_age(
+    data               = data,
+    target_column      = "dateOfBirth",
+    end_date           = Sys.Date(),
+    age_in             = "days",
+    na_strings         = "-99"
+  )
+  expect_s3_class(age, "data.frame")
+  expect_identical(ncol(age), 9L)
+  expect_identical(names(age)[9L], "age_in_days")
+})

--- a/tests/testthat/test-replace_missing_values.R
+++ b/tests/testthat/test-replace_missing_values.R
@@ -1,16 +1,18 @@
 data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
-test_that("replace_missing_values works", {
-  cleaned_data <- replace_missing_values(
-    data           = data,
-    target_columns = "sex",
-    na_strings     = "-99"
-  )
-  expect_s3_class(cleaned_data, "data.frame")
-  expect_false("-99" %in% cleaned_data[["sex"]])
-  expect_true(anyNA(cleaned_data[["sex"]]))
+test_that("replace_missing_values works when both target_columns and na_strings
+          are provided", {
+            cleaned_data <- replace_missing_values(
+              data           = data,
+              target_columns = "sex",
+              na_strings     = "-99"
+            )
+            expect_s3_class(cleaned_data, "data.frame")
+            expect_false("-99" %in% cleaned_data[["sex"]])
+            expect_true(anyNA(cleaned_data[["sex"]]))
+            expect_true(all(is.na(cleaned_data[["sex"]][data[["sex"]] == "-99"]))) # nolint: line_length_linter
 })
 
-test_that("replace_missing_values works", {
+test_that("replace_missing_values works when target_columns is set to NULL", {
   cleaned_data <- replace_missing_values(
     data           = data,
     target_columns = NULL,
@@ -19,8 +21,8 @@ test_that("replace_missing_values works", {
   expect_s3_class(cleaned_data, "data.frame")
   expect_false("-99" %in% cleaned_data[["sex"]])
   expect_false("-99" %in% cleaned_data[["dateOfBirth"]])
-  expect_true(anyNA(cleaned_data[["sex"]]))
-  expect_true(anyNA(cleaned_data[["dateOfBirth"]]))
+  expect_true(all(is.na(cleaned_data[["sex"]][data[["sex"]] == "-99"])))
+  expect_true(all(is.na(cleaned_data[["dateOfBirth"]][data[["dateOfBirth"]] == "-99"]))) # nolint: line_length_linter
 })
 
 test_that("replace_missing_values fails as expected", {

--- a/tests/testthat/test-replace_missing_values.R
+++ b/tests/testthat/test-replace_missing_values.R
@@ -1,5 +1,4 @@
 data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
-
 test_that("replace_missing_values works", {
   cleaned_data <- replace_missing_values(
     data           = data,

--- a/vignettes/cleanepi.Rmd
+++ b/vignettes/cleanepi.Rmd
@@ -489,6 +489,11 @@ data <- replace_missing_values(data           = data,
                                target_columns = "dateOfBirth",
                                na_strings     = "-99")
 
+# calculate_age() EXPECTS DATE VALUES IN ISO FORMAT. 
+data <- standardize_dates(data            = data,
+                          target_columns  = "dateOfBirth",
+                          error_tolerance = 0.0)
+
 # CALCULATE INDIVIDUAL AGE IN YEARS FROM THE 'dateOfBirth' COLUMN AND SEND THE
 # REMAINDER IN MONTHS
 age <- calculate_age(
@@ -504,6 +509,7 @@ data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
 age  <- data |>
   replace_missing_values(target_columns = "dateOfBirth",
                          na_strings     = "-99") |>
+  standardize_dates(target_columns  = "dateOfBirth", error_tolerance = 0.0) |>
   calculate_age(target_column      = "dateOfBirth",
                 end_date           = Sys.Date(),
                 age_in             = "years",

--- a/vignettes/cleanepi.Rmd
+++ b/vignettes/cleanepi.Rmd
@@ -473,18 +473,22 @@ The `calculate_age()` function computes the ages of individuals, expressed in ye
 2. **target_column**: A vector of the name of the column containing the birth or relevant  dates for which the age is being calculated (required).
 3. **end_date**: This is the reference date used to calculate the age of individuals (required). The function computes the age relative to this date.
 4. **age_in**: This parameter determines the unit in which the age is expressed (required). It  can be specified as "years", "months", "weeks", or "days". By default, the age is calculated in years if this parameter is not provided.
-5. **na_strings**: This is an extra parameters that is only needed when there are missing values in the date column of interest. It will be used to replace those missing values into `NA` prior to the age calculation.
+5. **na_strings**: This argument is only needed when there are missing values in the date column of interest. It will be used to replace those missing values into `NA` prior to the age calculation.
+6. **age_column_name**: A string for the name of the age column added to the input data. The default is `age_in_*` where `*` represents the unit specified in the 'age_in' argument.
+7. **age_remainder_unit**: A parameter used to determine the number of the remaining days (remainder_days) or weeks (remainder_weeks) or months (remainder_months), depending on the value of the 'age_remainder_unit' parameter, after calculating the age.
 
 With these arguments, the function offers flexibility in determining the age of individuals based on different units and reference dates. It facilitates various analytics tasks where age computation is a necessary component, providing users with the ability to customize the output according to their specific requirements.
 
 ```{r eval=TRUE}
 # CALCULATE INDIVIDUAL AGE FROM THE 'dateOfBirth' COLUMN
 age <- calculate_age(
-  data          = readRDS(system.file("extdata", "test_df.RDS",
-                                      package = "cleanepi")),
-  target_column = "dateOfBirth",
-  age_in        = "days",
-  na_strings    = "-99"
+  data               = readRDS(system.file("extdata", "test_df.RDS",
+                                           package = "cleanepi")),
+  target_column      = "dateOfBirth",
+  end_date           = Sys.Date(),
+  age_in             = "months",
+  age_remainder_unit = "weeks",
+  na_strings         = "-99"
 )
 ```
 

--- a/vignettes/cleanepi.Rmd
+++ b/vignettes/cleanepi.Rmd
@@ -486,7 +486,7 @@ data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
 data <- replace_missing_values(data           = data,
                                target_columns = "dateOfBirth",
                                na_strings     = "-99")
-                                           
+
 # CALCULATE INDIVIDUAL AGE IN YEARS FROM THE 'dateOfBirth' COLUMN AND SEND THE
 # REMAINDER IN MONTHS
 age <- calculate_age(

--- a/vignettes/cleanepi.Rmd
+++ b/vignettes/cleanepi.Rmd
@@ -471,7 +471,9 @@ The `calculate_age()` function computes the ages of individuals, expressed in ye
 
 1. **data**: The input dataset (required).
 2. **target_column**: A vector of the name of the column containing the birth or relevant  dates for which the age is being calculated (required).
-3. **end_date**: This is the reference date used to calculate the age of individuals (required). The function computes the age relative to this date.
+3. **end_date**: This is the reference date used to calculate the age of individuals (required). The function computes the age relative to this date. The default value is today's date (`Sys.Date()`)
+> The format required for this argument is `%Y-%m-%d` ("2024-12-31" for 31st of December 2024).
+
 4. **age_in**: This parameter determines the unit in which the age is expressed (required). It  can be specified as "years", "months", "weeks", or "days". By default, the age is calculated in years if this parameter is not provided.
 5. **age_column_name**: A string for the name of the age column added to the input data. The default is `age_in_*` where `*` represents the unit specified in the 'age_in' argument.
 6. **age_remainder_unit**: A parameter used to determine the number of the remaining days (remainder_days) or weeks (remainder_weeks) or months (remainder_months), depending on the value of the 'age_remainder_unit' parameter, after calculating the age.

--- a/vignettes/cleanepi.Rmd
+++ b/vignettes/cleanepi.Rmd
@@ -473,23 +473,39 @@ The `calculate_age()` function computes the ages of individuals, expressed in ye
 2. **target_column**: A vector of the name of the column containing the birth or relevant  dates for which the age is being calculated (required).
 3. **end_date**: This is the reference date used to calculate the age of individuals (required). The function computes the age relative to this date.
 4. **age_in**: This parameter determines the unit in which the age is expressed (required). It  can be specified as "years", "months", "weeks", or "days". By default, the age is calculated in years if this parameter is not provided.
-5. **na_strings**: This argument is only needed when there are missing values in the date column of interest. It will be used to replace those missing values into `NA` prior to the age calculation.
-6. **age_column_name**: A string for the name of the age column added to the input data. The default is `age_in_*` where `*` represents the unit specified in the 'age_in' argument.
-7. **age_remainder_unit**: A parameter used to determine the number of the remaining days (remainder_days) or weeks (remainder_weeks) or months (remainder_months), depending on the value of the 'age_remainder_unit' parameter, after calculating the age.
+5. **age_column_name**: A string for the name of the age column added to the input data. The default is `age_in_*` where `*` represents the unit specified in the 'age_in' argument.
+6. **age_remainder_unit**: A parameter used to determine the number of the remaining days (remainder_days) or weeks (remainder_weeks) or months (remainder_months), depending on the value of the 'age_remainder_unit' parameter, after calculating the age.
 
 With these arguments, the function offers flexibility in determining the age of individuals based on different units and reference dates. It facilitates various analytics tasks where age computation is a necessary component, providing users with the ability to customize the output according to their specific requirements.
 
 ```{r eval=TRUE}
-# CALCULATE INDIVIDUAL AGE FROM THE 'dateOfBirth' COLUMN
+# IMPORT THE INPUT DATA
+data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
+
+# REPLACE MISSING VALUES IN TARGET COLUMNS WITH `NA`
+data <- replace_missing_values(data           = data,
+                               target_columns = "dateOfBirth",
+                               na_strings     = "-99")
+                                           
+# CALCULATE INDIVIDUAL AGE IN YEARS FROM THE 'dateOfBirth' COLUMN AND SEND THE
+# REMAINDER IN MONTHS
 age <- calculate_age(
-  data               = readRDS(system.file("extdata", "test_df.RDS",
-                                           package = "cleanepi")),
+  data               = data,
   target_column      = "dateOfBirth",
   end_date           = Sys.Date(),
-  age_in             = "months",
-  age_remainder_unit = "weeks",
-  na_strings         = "-99"
+  age_in             = "years",
+  age_remainder_unit = "months"
 )
+
+# USING THE dplyr SYNTHAX
+data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
+age  <- data |>
+  replace_missing_values(target_columns = "dateOfBirth",
+                         na_strings     = "-99") |>
+  calculate_age(target_column      = "dateOfBirth",
+                end_date           = Sys.Date(),
+                age_in             = "years",
+                age_remainder_unit = "months")
 ```
 
 The `calculate_age()` function augments the input dataset by adding one or two extra columns containing age-related information. These additional columns are as follows:


### PR DESCRIPTION
Hi @Karim-Mane, this PR aims to fix #72. Please let me know if this is what you were looking for. I have also reduced the use of {dplyr} and simplified the function, but let me know if you preferred the previous implementation.

1.  Adds the argument `age_column_name` with a default value of `"age_<UNIT>"`, where `UNIT` is the time unit passed to `age_in`;
2. Adds the argument `age_remainder_unit` with allowed options "days", "weeks", and "months" - defaults to "days" (may wish to change this).