### PR TITLE
make sure all cleaning operations are performed on request only

### DIFF
--- a/R/clean_data.R
+++ b/R/clean_data.R
@@ -124,8 +124,10 @@ clean_data <- function(
   ## | are cleaned based using {base r} and {epitrix} packages.
   ## | Column names in 'keep' will not be modified.
   ## -----
-  R.utils::cat("\ncleaning column names")
-  data <- standardize_column_names(data = data, keep = params[["keep"]])
+  if (!is.null(params[["keep"]])) {
+    R.utils::cat("\ncleaning column names")
+    data <- standardize_column_names(data = data, keep = params[["keep"]])
+  }
 
   ## -----
   ## | we choose to standardize on the value for the missing data.
@@ -168,14 +170,16 @@ clean_data <- function(
   ## | detect and convert columns with Date values. This conversion will make it
   ## | easy to apply the functions that operate on variables of type Date.
   ## -----
-  R.utils::cat("\nstandardising date columns")
-  data <- standardize_dates(
-    data            = data,
-    target_columns  = params[["standardize_date"]][["target_columns"]],
-    format          = params[["standardize_date"]][["format"]],
-    timeframe       = params[["standardize_date"]][["timeframe"]],
-    error_tolerance = params[["standardize_date"]][["error_tolerance"]]
-  )
+  if (!is.null(params[["standardize_date"]])) {
+    R.utils::cat("\nstandardising date columns")
+    data <- standardize_dates(
+      data            = data,
+      target_columns  = params[["standardize_date"]][["target_columns"]],
+      format          = params[["standardize_date"]][["format"]],
+      timeframe       = params[["standardize_date"]][["timeframe"]],
+      error_tolerance = params[["standardize_date"]][["error_tolerance"]]
+    )
+  }
 
   ## -----
   ## | We check whether the format of the subject IDs complies with the expected


### PR DESCRIPTION
This issue is solved by making sure all operations are performed on request i.e. they are made explicit (the corresponding parameters should not be `NULL`). Also all exported functions are (or will be) made independent of each other. This way, the user have control over the operations, with the ability to specify them in a pipable way or calling them one after the other.
