### PR TITLE
Run `styler::style_pkg()` to make code formatting more consistent

### DIFF
--- a/R/check_date_sequence.R
+++ b/R/check_date_sequence.R
@@ -37,9 +37,11 @@
 #'   target_columns = c("date_first_pcr_positive_test", "date.of.admission")
 #' )
 check_date_sequence <- function(data, target_columns) {
-  checkmate::assert_vector(target_columns, any.missing = FALSE, min.len = 1L,
-                           max.len = dim(data)[2], null.ok = FALSE,
-                           unique = TRUE)
+  checkmate::assert_vector(target_columns,
+    any.missing = FALSE, min.len = 1L,
+    max.len = dim(data)[2], null.ok = FALSE,
+    unique = TRUE
+  )
   checkmate::assert_data_frame(data, null.ok = FALSE)
 
   # get the correct names in case some have been modified - see the
@@ -52,7 +54,8 @@ check_date_sequence <- function(data, target_columns) {
   # check if all columns are part of the data frame
   if (any(missing_cols)) {
     warning("Removing unrecognised column name: ", target_columns[missing_cols],
-            call. = FALSE)
+      call. = FALSE
+    )
     target_columns <- target_columns[!missing_cols]
     if (length(target_columns) < 2L) {
       stop("\nAt least 2 event dates are required!")
@@ -60,19 +63,22 @@ check_date_sequence <- function(data, target_columns) {
   }
 
   # checking the date sequence
-  tmp_data   <- data %>% dplyr::select(dplyr::all_of(target_columns))
+  tmp_data <- data %>% dplyr::select(dplyr::all_of(target_columns))
   order_date <- apply(tmp_data, 1L, is_date_sequence_ordered)
-  bad_order  <- which(!order_date)
+  bad_order <- which(!order_date)
   if (!all(order_date)) {
     tmp_data <- tmp_data[bad_order, ]
     # adding incorrect records to the report
-    data     <- add_to_report(x     = data,
-                              key   = "incorrect_date_sequence",
-                              value = tmp_data)
+    data <- add_to_report(
+      x = data,
+      key = "incorrect_date_sequence",
+      value = tmp_data
+    )
     warning("Detected ", length(bad_order),
-            " incorrect date sequences at line(s): ",
-            toString(bad_order),
-            call. = FALSE)
+      " incorrect date sequences at line(s): ",
+      toString(bad_order),
+      call. = FALSE
+    )
   }
 
   return(data)

--- a/R/clean_data.R
+++ b/R/clean_data.R
@@ -62,27 +62,33 @@
 #' replace_missing_values <- list(target_columns = NULL, na_strings = "-99")
 #'
 #' # Parameters for duplicates removal across all columns
-#' remove_duplicates <- list(target_columns   = NULL)
+#' remove_duplicates <- list(target_columns = NULL)
 #'
 #' # Parameters for dates standardization
-#' standardize_dates <- list(target_columns  = NULL,
-#'                           error_tolerance = 0.4,
-#'                           format          = NULL,
-#'                           timeframe       = as.Date(c("1973-05-29",
-#'                                                       "2023-05-29")),
-#'                           orders          = list(
-#'                             world_named_months = c("Ybd", "dby"),
-#'                             world_digit_months = c("dmy", "Ymd"),
-#'                             US_formats         = c("Omdy", "YOmd")
-#'                           ),
-#'                           modern_excel    = TRUE)
+#' standardize_dates <- list(
+#'   target_columns = NULL,
+#'   error_tolerance = 0.4,
+#'   format = NULL,
+#'   timeframe = as.Date(c(
+#'     "1973-05-29",
+#'     "2023-05-29"
+#'   )),
+#'   orders = list(
+#'     world_named_months = c("Ybd", "dby"),
+#'     world_digit_months = c("dmy", "Ymd"),
+#'     US_formats         = c("Omdy", "YOmd")
+#'   ),
+#'   modern_excel = TRUE
+#' )
 #'
 #' # Parameters for subject IDs standardization
-#' standardize_subject_ids <- list(target_columns = "study_id",
-#'                                 prefix         = "PS",
-#'                                 suffix         = "P2",
-#'                                 range          = c(1, 100),
-#'                                 nchar          = 7)
+#' standardize_subject_ids <- list(
+#'   target_columns = "study_id",
+#'   prefix = "PS",
+#'   suffix = "P2",
+#'   range = c(1, 100),
+#'   nchar = 7
+#' )
 #'
 #' to_numeric <- list(target_columns = "sex", lang = "en")
 #'
@@ -90,8 +96,9 @@
 #' # dictionary = NULL the dictionary-based cleaning will not be performed here
 #'
 #' cleaned_data <- clean_data(
-#'   data   = readRDS(system.file("extdata", "test_df.RDS",
-#'                                package = "cleanepi")),
+#'   data = readRDS(system.file("extdata", "test_df.RDS",
+#'     package = "cleanepi"
+#'   )),
 #'   params = list(
 #'     standardize_column_names = standardize_col_names,
 #'     remove_constants         = remove_cte,
@@ -112,10 +119,12 @@ clean_data <- function(data, params = NULL) {
   checkmate::assert_list(params, min.len = 1L, max.len = 10L, null.ok = TRUE)
   checkmate::check_names(
     params,
-    subset.of = c("standardize_column_names", "remove_constants",
-                  "replace_missing_values", "remove_duplicates",
-                  "standardize_dates", "standardize_subject_ids",
-                  "to_numeric", "dictionary", "check_date_sequence", "span")
+    subset.of = c(
+      "standardize_column_names", "remove_constants",
+      "replace_missing_values", "remove_duplicates",
+      "standardize_dates", "standardize_subject_ids",
+      "to_numeric", "dictionary", "check_date_sequence", "span"
+    )
   )
 
   ## -----

--- a/R/clean_data_helpers.R
+++ b/R/clean_data_helpers.R
@@ -15,23 +15,28 @@ scan_columns <- function(x) {
 
   # --- get the proportion of NA ---
   are_na <- round((sum(is.na(x)) / n_rows), 6L)
-  x      <- x[!is.na(x)]
+  x <- x[!is.na(x)]
 
   # --- get the proportion of numeric values ---
-  tmp         <- suppressWarnings(as.numeric(x))
+  tmp <- suppressWarnings(as.numeric(x))
   are_numeric <- round((sum(!is.na(tmp)) / n_rows), 6L)
 
   # --- get the proportion of date values ---
-  x        <- x[which(is.na(tmp))]
+  x <- x[which(is.na(tmp))]
   are_date <- 0L
-  if (!is.null(lubridate::guess_formats(x, c("ymd", "ydm", "dmy", "mdy", "myd",
-                                             "dym", "Ymd", "Ydm", "dmY", "mdY",
-                                             "mYd", "dYm")))) {
+  if (!is.null(lubridate::guess_formats(x, c(
+    "ymd", "ydm", "dmy", "mdy", "myd",
+    "dym", "Ymd", "Ydm", "dmY", "mdY",
+    "mYd", "dYm"
+  )))) {
     x <- suppressWarnings(
       as.Date(
         lubridate::parse_date_time(
-          x, orders = c("ymd", "ydm", "dmy", "mdy", "myd", "dym", "Ymd", "Ydm",
-                        "dmY", "mdY", "mYd", "dYm")
+          x,
+          orders = c(
+            "ymd", "ydm", "dmy", "mdy", "myd", "dym", "Ymd", "Ydm",
+            "dmY", "mdY", "mYd", "dYm"
+          )
         )
       )
     )
@@ -39,11 +44,11 @@ scan_columns <- function(x) {
   }
 
   # --- get the proportion of logical values ---
-  are_logical   <- round((sum(is.logical(x)) / n_rows), 6L)
+  are_logical <- round((sum(is.logical(x)) / n_rows), 6L)
 
   # --- get the proportion of character values ---
   are_character <- round((1.0 - (are_na + are_numeric +
-                                   are_date + are_logical)), 6L)
+    are_date + are_logical)), 6L)
 
   # --- return the output ---
   return(c(are_na, are_numeric, are_date, are_character, are_logical))
@@ -63,14 +68,17 @@ scan_columns <- function(x) {
 #' @examples
 #' scan_result <- scan_data(
 #'   data = readRDS(system.file("extdata", "messy_data.RDS",
-#'                              package = "cleanepi"))
+#'     package = "cleanepi"
+#'   ))
 #' )
 scan_data <- function(data) {
-  scan_result           <- data.frame(t(apply(data, 2L, scan_columns)))
-  names(scan_result)    <- c("missing", "numeric", "date", "character",
-                             "logical")
-  row_names             <- rownames(scan_result)
+  scan_result <- data.frame(t(apply(data, 2L, scan_columns)))
+  names(scan_result) <- c(
+    "missing", "numeric", "date", "character",
+    "logical"
+  )
+  row_names <- rownames(scan_result)
   rownames(scan_result) <- NULL
-  scan_result           <- cbind(Field_names = row_names, scan_result)
+  scan_result <- cbind(Field_names = row_names, scan_result)
   return(scan_result)
 }

--- a/R/column_name_standardization.R
+++ b/R/column_name_standardization.R
@@ -19,31 +19,37 @@
 #' # do not rename 'date.of.admission'
 #' cleaned_data <- standardize_column_names(
 #'   data = readRDS(system.file("extdata", "test_df.RDS",
-#'                              package = "cleanepi")),
+#'     package = "cleanepi"
+#'   )),
 #'   keep = "date.of.admission"
 #' )
 #'
 #' # do not rename 'date.of.admission', but rename 'dateOfBirth' and 'sex' to
 #' # 'DOB' and 'gender' respectively
 #' cleaned_data <- standardize_column_names(
-#'   data   = readRDS(system.file("extdata", "test_df.RDS",
-#'                                package = "cleanepi")),
-#'   keep   = "date.of.admission",
+#'   data = readRDS(system.file("extdata", "test_df.RDS",
+#'     package = "cleanepi"
+#'   )),
+#'   keep = "date.of.admission",
 #'   rename = c(DOB = "dateOfBirth", gender = "sex")
 #' )
 #'
 standardize_column_names <- function(data, keep = NULL, rename = NULL) {
-  checkmate::assert_vector(keep, min.len = 0L, max.len = ncol(data),
-                           null.ok = TRUE,
-                           any.missing = FALSE)
-  checkmate::assert_character(rename, min.len = 0L, null.ok = TRUE,
-                              any.missing = FALSE)
+  checkmate::assert_vector(keep,
+    min.len = 0L, max.len = ncol(data),
+    null.ok = TRUE,
+    any.missing = FALSE
+  )
+  checkmate::assert_character(rename,
+    min.len = 0L, null.ok = TRUE,
+    any.missing = FALSE
+  )
   before <- colnames(data)
 
   # when rename is not NULL, get the indices of the old column names as a vector
   # and name them with the new names
   if (!is.null(rename)) {
-    new_names    <- names(rename)
+    new_names <- names(rename)
     current_names <- unname(rename)
     stopifnot(
       "Unrecognised column names specified in 'rename'" =
@@ -51,7 +57,7 @@ standardize_column_names <- function(data, keep = NULL, rename = NULL) {
       "Replace column names already exists" =
         !any(new_names %in% before)
     )
-    rename        <- match(current_names, before)
+    rename <- match(current_names, before)
     names(rename) <- new_names
   }
 
@@ -59,8 +65,9 @@ standardize_column_names <- function(data, keep = NULL, rename = NULL) {
   # also account for when target columns are provided as a vector or column
   # name or column indices or NULL
   keep <- get_target_column_names(data,
-                                  target_columns = keep,
-                                  cols           = NULL)
+    target_columns = keep,
+    cols           = NULL
+  )
   kept <- before %in% keep
 
   # if they're anything apart from ASCII e.g. arabic, throw error
@@ -71,12 +78,12 @@ standardize_column_names <- function(data, keep = NULL, rename = NULL) {
     sep = "_"
   )
   if (!all(kept)) {
-    after[kept]  <- before[kept]
+    after[kept] <- before[kept]
   }
-  after[rename]  <- names(rename)
+  after[rename] <- names(rename)
   colnames(data) <- after
-  colnames_info  <- data.frame(before, after)
-  data           <- add_to_report(data, "colnames", colnames_info)
+  colnames_info <- data.frame(before, after)
+  data <- add_to_report(data, "colnames", colnames_info)
   return(data)
 }
 
@@ -103,7 +110,7 @@ retrieve_column_names <- function(data, target_columns) {
   }
 
   # extract the report object to make it easily accessible
-  report    <- attr(data, "report")
+  report <- attr(data, "report")
   if (!"colnames" %in% names(report)) {
     return(target_columns)
   }
@@ -115,13 +122,13 @@ retrieve_column_names <- function(data, target_columns) {
 
   # detect the current names
   # identify the old names
-  new_names      <- target_columns[target_columns %in% names(data)]
+  new_names <- target_columns[target_columns %in% names(data)]
   target_columns <- target_columns[!(target_columns %in% names(data))]
   if ("colnames" %in% names(report) &&
-      all(target_columns %in% report[["colnames"]][["before"]])) {
+    all(target_columns %in% report[["colnames"]][["before"]])) {
     all_column_names <- report[["colnames"]]
-    idx              <- match(target_columns, all_column_names[["before"]])
-    new_names        <- c(new_names, all_column_names[["after"]][idx])
+    idx <- match(target_columns, all_column_names[["before"]])
+    new_names <- c(new_names, all_column_names[["after"]][idx])
   }
 
   return(new_names)

--- a/R/convert_numeric_to_date.R
+++ b/R/convert_numeric_to_date.R
@@ -23,11 +23,15 @@
 convert_numeric_to_date <- function(data, target_columns, ref_date,
                                     forward = TRUE) {
   if (!checkmate::test_character(ref_date, len = 1L, null.ok = FALSE)) {
-    checkmate::assert_date(ref_date, any.missing = FALSE, min.len = 1L,
-                           max.len = 1L, null.ok = FALSE)
+    checkmate::assert_date(ref_date,
+      any.missing = FALSE, min.len = 1L,
+      max.len = 1L, null.ok = FALSE
+    )
   }
-  checkmate::assert_vector(target_columns, min.len = 1, max.len = ncol(data),
-                           null.ok = FALSE, any.missing = FALSE)
+  checkmate::assert_vector(target_columns,
+    min.len = 1, max.len = ncol(data),
+    null.ok = FALSE, any.missing = FALSE
+  )
   checkmate::assert_data_frame(data, null.ok = FALSE, min.cols = 1L)
 
   # get the correct names in case some have been modified - see the

--- a/R/convert_to_numeric.R
+++ b/R/convert_to_numeric.R
@@ -18,20 +18,25 @@
 #'
 #' @examples
 #' dat <- convert_to_numeric(
-#'   data           = readRDS(system.file("extdata", "messy_data.RDS",
-#'                                        package = "cleanepi")),
+#'   data = readRDS(system.file("extdata", "messy_data.RDS",
+#'     package = "cleanepi"
+#'   )),
 #'   target_columns = "age",
-#'   lang           = "en"
+#'   lang = "en"
 #' )
 convert_to_numeric <- function(data, target_columns = NULL,
                                lang = c("en", "fr", "es")) {
-  checkmate::assert_data_frame(data, min.rows = 1L, min.cols = 1L,
-                               null.ok = FALSE)
-  checkmate::assert_vector(target_columns, any.missing = FALSE, min.len = 0L,
-                           null.ok = TRUE)
+  checkmate::assert_data_frame(data,
+    min.rows = 1L, min.cols = 1L,
+    null.ok = FALSE
+  )
+  checkmate::assert_vector(target_columns,
+    any.missing = FALSE, min.len = 0L,
+    null.ok = TRUE
+  )
   lang <- match.arg(lang)
   if (is.null(target_columns)) {
-    scan_res       <- scan_data(data = data)
+    scan_res <- scan_data(data = data)
     target_columns <- detect_to_numeric_columns(scan_res)
   }
 
@@ -42,11 +47,13 @@ convert_to_numeric <- function(data, target_columns = NULL,
 
   stopifnot("Please specify the target columns." = length(target_columns) > 0L)
   for (col in target_columns) {
-    data[[col]]  <- numberize::numberize(text = data[[col]], lang = lang)
+    data[[col]] <- numberize::numberize(text = data[[col]], lang = lang)
   }
-  data           <- add_to_report(x     = data,
-                                  key   = "converted_into_numeric",
-                                  value = paste(target_columns, sep = ", "))
+  data <- add_to_report(
+    x = data,
+    key = "converted_into_numeric",
+    value = paste(target_columns, sep = ", ")
+  )
   return(data)
 }
 
@@ -60,25 +67,28 @@ convert_to_numeric <- function(data, target_columns = NULL,
 #' @keywords internal
 #'
 detect_to_numeric_columns <- function(scan_res) {
-  checkmate::assert_data_frame(scan_res, min.rows = 1L, min.cols = 1L,
-                               null.ok = FALSE)
+  checkmate::assert_data_frame(scan_res,
+    min.rows = 1L, min.cols = 1L,
+    null.ok = FALSE
+  )
   to_numeric <- vector(mode = "character", length = 0L)
   for (col in scan_res[["Field_names"]]) {
     idx <- match(col, scan_res[["Field_names"]])
-    values        <- scan_res[idx, 2L:ncol(scan_res)]
+    values <- scan_res[idx, 2L:ncol(scan_res)]
     names(values) <- colnames(scan_res)[2L:ncol(scan_res)]
-    values        <- values[which(values > 0L)]
+    values <- values[which(values > 0L)]
     if ("missing" %in% names(values)) {
       values <- values[-(which(names(values) == "missing"))]
     }
     if (length(values) == 2L && "numeric" %in% names(values) &&
-        "character" %in% names(values)) {
+      "character" %in% names(values)) {
       if (values[["numeric"]] > (2.0 * values[["character"]])) {
         to_numeric <- c(to_numeric, col)
       } else if (values[["numeric"]] < (2L * values[["character"]])) {
-          warning(sprintf("In '%s' column, the number of numeric values", col),
-                          " is same as the number of character values",
-                  call. = FALSE)
+        warning(sprintf("In '%s' column, the number of numeric values", col),
+          " is same as the number of character values",
+          call. = FALSE
+        )
       }
     } else {
       next

--- a/R/data-common_na_strings.R
+++ b/R/data-common_na_strings.R
@@ -1,6 +1,6 @@
 #' Common strings representing missing values
 #'
-#'This vector contains common values of NA (missing) and is intended for
+#' This vector contains common values of NA (missing) and is intended for
 #' use within \{cleanepi\} functions [replace_missing_values()].
 #' The current list of strings used can be found by printing out
 #' `common_na_strings`. It serves as a helpful tool to explore your data

--- a/R/date_standardization_helpers.R
+++ b/R/date_standardization_helpers.R
@@ -9,12 +9,11 @@
 #' @keywords internal
 #'
 date_check_timeframe <- function(first_date, last_date) {
-
   # make sure that they are single character strings in ISO 8601 format.
   iso_8601 <- "[0-9]{4}-(0|1(?=[0-2]))[0-9]-([0-2]|3(?=[0-1]))[0-9]"
 
   first_date_is_charcater <- is.character(first_date)
-  first_date_has_len_1    <- length(first_date) == 1L
+  first_date_has_len_1 <- length(first_date) == 1L
   first_date_has_iso_8601 <- grepl(iso_8601, first_date, perl = TRUE)
   verdict <- first_date_is_charcater & first_date_has_len_1 &
     first_date_has_iso_8601
@@ -23,7 +22,7 @@ date_check_timeframe <- function(first_date, last_date) {
   }
 
   last_date_is_charcater <- is.character(last_date)
-  last_date_has_len_1    <- length(last_date) == 1L
+  last_date_has_len_1 <- length(last_date) == 1L
   last_date_has_iso_8601 <- grepl(iso_8601, last_date, perl = TRUE)
   verdict <- last_date_is_charcater & last_date_has_len_1 &
     last_date_has_iso_8601
@@ -37,8 +36,10 @@ date_check_timeframe <- function(first_date, last_date) {
   }
 
   if (!inherits(first_date, "Date") || !inherits(last_date, "Date")) {
-    stop("first_date and last_date must be Date objects or characters in",
-         "yyyy-mm-dd format.")
+    stop(
+      "first_date and last_date must be Date objects or characters in",
+      "yyyy-mm-dd format."
+    )
   }
   return(list(first_date, last_date))
 }
@@ -59,7 +60,6 @@ date_check_timeframe <- function(first_date, last_date) {
 #' @keywords internal
 #'
 date_trim_outliers <- function(new_dates, dmin, dmax, cols, original_dates) {
-
   # filter out the dates that are below the threshold
   outsiders <- new_dates < dmin | new_dates > dmax
   outsiders[is.na(outsiders)] <- FALSE
@@ -68,9 +68,11 @@ date_trim_outliers <- function(new_dates, dmin, dmax, cols, original_dates) {
   out_of_boundaries <- NULL
   if (any(outsiders)) {
     idx <- which(outsiders)
-    out_of_boundaries <- data.frame(idx            = idx,
-                                    column         = rep(cols, length(idx)),
-                                    original_value = original_dates[idx])
+    out_of_boundaries <- data.frame(
+      idx = idx,
+      column = rep(cols, length(idx)),
+      original_value = original_dates[idx]
+    )
   }
   # mark the bad dates as NA
   new_dates[outsiders] <- as.Date(NA_character_)
@@ -94,17 +96,18 @@ date_trim_outliers <- function(new_dates, dmin, dmax, cols, original_dates) {
 date_convert <- function(data, cols, error_tolerance,
                          timeframe = NULL, orders, modern_excel) {
   # Guess the date using Thibault's parser
-  new_dates           <- data[[cols]]
+  new_dates <- data[[cols]]
   if (!inherits(data[[cols]], "Date")) {
-    date_guess_res    <- date_guess(new_dates,
-                                    orders       = orders,
-                                    modern_excel = modern_excel,
-                                    column_name  = cols)
-    new_dates         <- date_guess_res[["res"]]
+    date_guess_res <- date_guess(new_dates,
+      orders       = orders,
+      modern_excel = modern_excel,
+      column_name  = cols
+    )
+    new_dates <- date_guess_res[["res"]]
     multi_format_dates <- date_guess_res[["multi_format"]]
     # report the multi formatted dates
     if (nrow(multi_format_dates)) {
-      data            <- add_to_report(
+      data <- add_to_report(
         x     = data,
         key   = "multi_format_dates",
         value = multi_format_dates
@@ -114,21 +117,25 @@ date_convert <- function(data, cols, error_tolerance,
 
   # Trim outliers i.e. date values that are out of the range of the provided
   # timeframe
-  outsiders        <- NULL
+  outsiders <- NULL
   if (!is.null(timeframe)) {
-    res            <- date_convert_and_update(data, timeframe, new_dates, cols,
-                                              error_tolerance)
-    data           <- res[["data"]]
-    outsiders      <- res[["outsiders"]]
+    res <- date_convert_and_update(
+      data, timeframe, new_dates, cols,
+      error_tolerance
+    )
+    data <- res[["data"]]
+    outsiders <- res[["outsiders"]]
   } else {
-    data[[cols]]   <- new_dates
+    data[[cols]] <- new_dates
   }
 
   # report the out of range dates
   if (!is.null(outsiders)) {
-    data         <- add_to_report(x     = data,
-                                  key   = "out_of_range_dates",
-                                  value = outsiders)
+    data <- add_to_report(
+      x = data,
+      key = "out_of_range_dates",
+      value = outsiders
+    )
   }
 
   return(data)
@@ -149,23 +156,25 @@ date_convert <- function(data, cols, error_tolerance,
 date_convert_and_update <- function(data, timeframe, new_dates, cols,
                                     error_tolerance = 0.5) {
   timeframe <- date_check_timeframe(timeframe[[1L]], timeframe[[2L]])
-  new_dates <- date_trim_outliers(new_dates,
-                                  timeframe[[1L]], timeframe[[2L]],
-                                  cols, data[[cols]])
-  na_before       <- sum(is.na(data[[cols]]))
-  na_after        <- sum(is.na(new_dates[["new_dates"]]))
+  new_dates <- date_trim_outliers(
+    new_dates,
+    timeframe[[1L]], timeframe[[2L]],
+    cols, data[[cols]]
+  )
+  na_before <- sum(is.na(data[[cols]]))
+  na_after <- sum(is.na(new_dates[["new_dates"]]))
   prop_successful <- (length(data[[cols]]) - na_after) / (length(data[[cols]]) - na_before) # nolint: line_length_linter
 
   # shape result depending on whether conversion was successful
   if (prop_successful > (1L - error_tolerance)) {
-    data[[cols]]   <- new_dates[["new_dates"]]
+    data[[cols]] <- new_dates[["new_dates"]]
   }
 
-  outsiders   <- new_dates[["outsiders"]]
+  outsiders <- new_dates[["outsiders"]]
   if (all(is.na(new_dates[["new_dates"]]))) {
     outsiders <- NULL
   }
-  report      <- attr(data, "report")
+  report <- attr(data, "report")
   if ("out_of_range_dates" %in% names(report)) {
     outsiders <- rbind(report[["out_of_range_dates"]], outsiders)
   }
@@ -185,46 +194,52 @@ date_convert_and_update <- function(data, timeframe, new_dates, cols,
 date_guess_convert <- function(data, error_tolerance, timeframe,
                                orders, modern_excel) {
   # guess and convert for column of type character, factor and POSIX
-  are_posix      <- which(apply(data, 2, inherits, "POSIXt"))
+  are_posix <- which(apply(data, 2, inherits, "POSIXt"))
   are_characters <- which(apply(data, 2, inherits, "character"))
-  are_factors    <- which(apply(data, 2, inherits, "factor"))
-  are_dates      <- which(apply(data, 2, inherits, "Date"))
+  are_factors <- which(apply(data, 2, inherits, "factor"))
+  are_dates <- which(apply(data, 2, inherits, "Date"))
 
   # convert POSIX to date
   for (i in are_posix) {
-    data[[i]]   <- as.Date(data[[i]])
+    data[[i]] <- as.Date(data[[i]])
   }
 
   # convert characters and factors to date when applicable
-  of_interest       <- c(are_characters, are_factors, are_dates, are_posix)
+  of_interest <- c(are_characters, are_factors, are_dates, are_posix)
   multi_forma_dates <- NULL
   for (i in names(of_interest)) {
-    date_guess_res    <- date_guess(data[[i]], orders = orders,
-                                    modern_excel = modern_excel,
-                                    column_name = i)
-    new_dates         <- date_guess_res[["res"]]
-    multi_format      <- date_guess_res[["multi_format"]]
+    date_guess_res <- date_guess(data[[i]],
+      orders = orders,
+      modern_excel = modern_excel,
+      column_name = i
+    )
+    new_dates <- date_guess_res[["res"]]
+    multi_format <- date_guess_res[["multi_format"]]
     if (nrow(multi_format) > 0L) {
       multi_forma_dates <- rbind(multi_forma_dates, multi_format)
-                                 # cbind(field = i, multi_format))
+      # cbind(field = i, multi_format))
     }
 
     if (!all(is.na(new_dates)) && is.null(timeframe)) {
-      data[[i]]       <- new_dates
+      data[[i]] <- new_dates
     }
     if (!is.null(timeframe)) {
-      res             <- date_convert_and_update(data, timeframe, new_dates, i,
-                                                 error_tolerance)
-      data            <- res[["data"]]
-      data            <- add_to_report(x     = data,
-                                       key   = "out_of_range_dates",
-                                       value = res[["outsiders"]])
+      res <- date_convert_and_update(
+        data, timeframe, new_dates, i,
+        error_tolerance
+      )
+      data <- res[["data"]]
+      data <- add_to_report(
+        x = data,
+        key = "out_of_range_dates",
+        value = res[["outsiders"]]
+      )
     }
   }
 
   # report the multi formatted dates
   if (!is.null(multi_forma_dates)) {
-    data            <- add_to_report(
+    data <- add_to_report(
       x     = data,
       key   = "multi_format_dates",
       value = multi_forma_dates
@@ -321,7 +336,7 @@ date_check_column_existence <- function(data, date_column_names) {
 #' @keywords internal
 #'
 date_detect_separator <- function(x) {
-  sep                <- NULL
+  sep <- NULL
   special_characters <- c("-", "/", ",", " ")
   if (!is.na(x)) {
     sep <- NULL
@@ -344,18 +359,22 @@ date_detect_separator <- function(x) {
 #'
 date_detect_day_or_month <- function(x) {
   f1 <- NULL
-  full_days <- c("Monday", "Tuesday", "Wednesday", "Thursday",
-                 "Friday", "Saturday", "Sunday")
+  full_days <- c(
+    "Monday", "Tuesday", "Wednesday", "Thursday",
+    "Friday", "Saturday", "Sunday"
+  )
   abreviated_days <- c("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
   all_full_months <- c(month.name, toupper(month.name), tolower(month.name))
-  all_abb_months  <- c(month.abb, toupper(month.abb), tolower(month.abb))
-  all_full_days   <- c(full_days, toupper(full_days), tolower(full_days))
-  all_abb_days    <- c(abreviated_days, toupper(abreviated_days),
-                       tolower(abreviated_days))
-  in_full_month   <- x %in% all_full_months
-  in_abb_month    <- x %in% all_abb_months
-  in_full_day     <- x %in% all_full_days
-  in_abb_day      <- x %in% all_abb_days
+  all_abb_months <- c(month.abb, toupper(month.abb), tolower(month.abb))
+  all_full_days <- c(full_days, toupper(full_days), tolower(full_days))
+  all_abb_days <- c(
+    abreviated_days, toupper(abreviated_days),
+    tolower(abreviated_days)
+  )
+  in_full_month <- x %in% all_full_months
+  in_abb_month <- x %in% all_abb_months
+  in_full_day <- x %in% all_full_days
+  in_abb_day <- x %in% all_abb_days
   if (all(in_full_month)) {
     f1 <- "%B"
   } else if (all(in_abb_month)) {
@@ -382,9 +401,11 @@ date_detect_simple_format <- function(x) {
   if (all(nchar(x) == 4L)) {
     f1 <- "%Y" # year with century i.e 4 digits year
   } else if (any(nchar(x) == 4L) && any(nchar(x) == 2L)) {
-    stop("Detected different lengths in first digits of date column.\n",
-         "Please use same number of digits or specify the date format with",
-         "the 'format' argument.")
+    stop(
+      "Detected different lengths in first digits of date column.\n",
+      "Please use same number of digits or specify the date format with",
+      "the 'format' argument."
+    )
   } else if (all(nchar(x) == 2L)) {
     tmp <- as.numeric(x)
     if (all(tmp <= 12L)) {
@@ -422,35 +443,42 @@ date_get_format <- function(data, date_column_name, sep) {
   }
 
   # investigate the format among the date values that contain the separator
-  tmp_list                 <- strsplit(tmp_date_column,
-                                       sep[[1L]],
-                                       fixed = TRUE)
-  idx                      <- which(is.na(tmp_list))
+  tmp_list <- strsplit(tmp_date_column,
+    sep[[1L]],
+    fixed = TRUE
+  )
+  idx <- which(is.na(tmp_list))
   if (length(idx) > 0L) {
-    tmp_list[[idx]]        <- rep(NA, max(lengths(tmp_list)))
+    tmp_list[[idx]] <- rep(NA, max(lengths(tmp_list)))
   }
   part1 <- part2 <- part3 <- rep(NA, length(tmp_date_column))
   if (any(lengths(tmp_list) >= 1L)) {
-    part1 <- as.character(unlist(lapply(tmp_date_column,
-                                        date_get_part1,
-                                        sep[[1L]])))
+    part1 <- as.character(unlist(lapply(
+      tmp_date_column,
+      date_get_part1,
+      sep[[1L]]
+    )))
   }
   if (any(lengths(tmp_list) >= 2L)) {
-    part2 <- as.character(unlist(lapply(tmp_date_column,
-                                        date_get_part2,
-                                        sep[[1L]])))
+    part2 <- as.character(unlist(lapply(
+      tmp_date_column,
+      date_get_part2,
+      sep[[1L]]
+    )))
   }
   if (any(lengths(tmp_list) >= 3L)) {
-    part3 <- as.character(unlist(lapply(tmp_date_column,
-                                        date_get_part3,
-                                        sep[[1L]])))
+    part3 <- as.character(unlist(lapply(
+      tmp_date_column,
+      date_get_part3,
+      sep[[1L]]
+    )))
   }
 
-  f1       <- ifelse(all(is.na(part1)), NA, date_detect_format(part1))
-  f2       <- ifelse(all(is.na(part2)), NA, date_detect_format(part2))
-  f3       <- ifelse(all(is.na(part3)), NA, date_detect_format(part3))
-  idx      <- which(is.na(c(f1, f2, f3)))
-  format   <- NULL
+  f1 <- ifelse(all(is.na(part1)), NA, date_detect_format(part1))
+  f2 <- ifelse(all(is.na(part2)), NA, date_detect_format(part2))
+  f3 <- ifelse(all(is.na(part3)), NA, date_detect_format(part3))
+  idx <- which(is.na(c(f1, f2, f3)))
+  format <- NULL
   if (length(idx) == 0L) {
     format <- paste0(format, f1, sep[[1L]], f2, sep[[1L]], f3)
   } else if (idx == 3L) {
@@ -480,8 +508,10 @@ date_get_format <- function(data, date_column_name, sep) {
 #'
 date_make_format <- function(f1, f2, tmp_sep) {
   if (is.null(f1) && is.null(f2)) {
-    stop("Unrecognised date format.\n",
-         "Please specify the date format using the 'format' argument.")
+    stop(
+      "Unrecognised date format.\n",
+      "Please specify the date format using the 'format' argument."
+    )
   }
 
   return(paste(c(f1, f2), collapse = tmp_sep))
@@ -524,8 +554,10 @@ date_process <- function(x) {
 #'
 date_match_format_and_column <- function(target_columns, format) {
   if (length(target_columns) > 2L && length(format) == 2L) {
-    stop("Need to specify one format if all target columns have the same",
-         "format.\nProvide one format per target column, otherwise.")
+    stop(
+      "Need to specify one format if all target columns have the same",
+      "format.\nProvide one format per target column, otherwise."
+    )
   }
   if (length(target_columns) >= 1L && length(format) == 1L) {
     warning("Using ", format, " to standardize all columns...", call. = FALSE)

--- a/R/default_cleanepi_settings.R
+++ b/R/default_cleanepi_settings.R
@@ -14,7 +14,7 @@ default_cleanepi_settings <- function() {
     standardize_column_names = list(keep = NULL, rename = NULL),
     replace_missing_values = NULL,
     remove_duplicates = list(
-      target_columns   = NULL
+      target_columns = NULL
     ),
     remove_constants = list(cutoff = 1L),
     standardize_dates = NULL,

--- a/R/dev-utils.R
+++ b/R/dev-utils.R
@@ -1,11 +1,9 @@
 # This unexported function adds a custom item to `usethis::use_release_issue()`
 release_bullets <- function() {
-
   c(
     "Run `goodpractice::gp()`",
     "Review [WORDLIST](https://docs.cran.dev/spelling#wordlist)",
     "Check if `# nolint` comments are still needed with recent lintr releases",
     "All contributors to this release are acknowledged in some way"
   )
-
 }

--- a/R/dictionary_based_cleaning.R
+++ b/R/dictionary_based_cleaning.R
@@ -7,21 +7,29 @@
 #' @export
 #'
 #' @examples
-#' data           <- readRDS(system.file("extdata", "messy_data.RDS",
-#'                                       package = "cleanepi"))
+#' data <- readRDS(system.file("extdata", "messy_data.RDS",
+#'   package = "cleanepi"
+#' ))
 #' data$gender[2] <- "homme"
-#' cleaned_df     <- clean_using_dictionary(
-#'   data       = data,
+#' cleaned_df <- clean_using_dictionary(
+#'   data = data,
 #'   dictionary = readRDS(system.file("extdata", "test_dict.RDS",
-#'                                    package = "cleanepi"))
+#'     package = "cleanepi"
+#'   ))
 #' )
 clean_using_dictionary <- function(data, dictionary) {
-  checkmate::assert_data_frame(data, min.rows = 1L, min.cols = 1L,
-                               null.ok = FALSE)
-  checkmate::assert_data_frame(dictionary, min.rows = 1L, max.cols = 4L,
-                               null.ok = FALSE)
-  stopifnot(all(c("options", "values", "grp") %in% names(dictionary)),
-            all(unique(dictionary[["grp"]]) %in% names(data)))
+  checkmate::assert_data_frame(data,
+    min.rows = 1L, min.cols = 1L,
+    null.ok = FALSE
+  )
+  checkmate::assert_data_frame(dictionary,
+    min.rows = 1L, max.cols = 4L,
+    null.ok = FALSE
+  )
+  stopifnot(
+    all(c("options", "values", "grp") %in% names(dictionary)),
+    all(unique(dictionary[["grp"]]) %in% names(data))
+  )
 
   # detect misspelled options in the columns to clean
   misspelled_options <- detect_misspelled_options(data, dictionary)
@@ -29,21 +37,26 @@ clean_using_dictionary <- function(data, dictionary) {
   # correct the misspelled options if they exist
   if (length(misspelled_options) > 0L) {
     print_misspelled_values(misspelled_options)
-    message("Please add the misspelled options to the data dictionary using",
-            " the add_to_dictionary() function.")
+    message(
+      "Please add the misspelled options to the data dictionary using",
+      " the add_to_dictionary() function."
+    )
     misspelled_report <- construct_misspelled_report(misspelled_options, data)
     # add the result to the reporting object
-    data              <- add_to_report(x     = data,
-                                       key   = "misspelled_values",
-                                       value = misspelled_report)
+    data <- add_to_report(
+      x = data,
+      key = "misspelled_values",
+      value = misspelled_report
+    )
   }
   # perform the dictionary-based cleaning
-  data                <- suppressWarnings(
+  data <- suppressWarnings(
     matchmaker::match_df(data,
-                         dictionary = dictionary,
-                         from       = "options",
-                         to         = "values",
-                         by         = "grp")
+      dictionary = dictionary,
+      from       = "options",
+      to         = "values",
+      by         = "grp"
+    )
   )
 
   return(data)
@@ -63,11 +76,13 @@ clean_using_dictionary <- function(data, dictionary) {
 #'
 construct_misspelled_report <- function(misspelled_options, data) {
   checkmate::assert_list(misspelled_options, null.ok = FALSE)
-  result  <- NULL
+  result <- NULL
   for (opts in names(misspelled_options)) {
-    res   <- data.frame(idx    = misspelled_options[[opts]],
-                        column = rep(opts, length(misspelled_options[[opts]])),
-                        value  = data[[opts]][misspelled_options[[opts]]])
+    res <- data.frame(
+      idx = misspelled_options[[opts]],
+      column = rep(opts, length(misspelled_options[[opts]])),
+      value = data[[opts]][misspelled_options[[opts]]]
+    )
     result <- rbind(result, res)
   }
   return(result)
@@ -94,21 +109,27 @@ make_readcap_dictionary <- function(metadata,
                                     field_column,
                                     opt_column,
                                     field_type) {
-  checkmate::assert_data_frame(metadata, min.rows = 1L, min.cols = 1L,
-                               null.ok = FALSE)
+  checkmate::assert_data_frame(metadata,
+    min.rows = 1L, min.cols = 1L,
+    null.ok = FALSE
+  )
   checkmate::assert_character(opt_column, len = 1L, null.ok = FALSE)
   checkmate::assert_character(field_type, len = 1L, null.ok = FALSE)
   checkmate::assert_character(field_column, len = 1L, null.ok = FALSE)
 
   stopifnot(opt_column %in% names(metadata))
 
-  metadata     <- metadata[which(!is.na(metadata[[opt_column]]) &
-                                   metadata[[field_type]] != "calc"), ]
-  dictionary   <- NULL
+  metadata <- metadata[which(!is.na(metadata[[opt_column]]) &
+    metadata[[field_type]] != "calc"), ]
+  dictionary <- NULL
   for (i in seq_len(nrow(metadata))) {
-    dictionary <- rbind(dictionary,
-                        dictionary_make_metadata(metadata[[opt_column]][i],
-                                                 metadata[[field_column]][i]))
+    dictionary <- rbind(
+      dictionary,
+      dictionary_make_metadata(
+        metadata[[opt_column]][i],
+        metadata[[field_column]][i]
+      )
+    )
   }
   return(dictionary)
 }
@@ -124,15 +145,21 @@ make_readcap_dictionary <- function(metadata,
 #' @keywords internal
 #'
 dictionary_make_metadata <- function(x, field_column) {
-  splits          <- trimws(unlist(strsplit(x, "|", fixed = TRUE)))
-  combined_splits <- lapply(splits, function(x) { trimws(unlist(strsplit(x, ",", fixed = TRUE))) }) # nolint: line_length_linter
+  splits <- trimws(unlist(strsplit(x, "|", fixed = TRUE)))
+  combined_splits <- lapply(splits, function(x) {
+    trimws(unlist(strsplit(x, ",", fixed = TRUE)))
+  }) # nolint: line_length_linter
   combined_splits <- do.call(rbind.data.frame, combined_splits)
-  res             <- data.frame(options = combined_splits[, 1L],
-                                values  = combined_splits[, 2L],
-                                grp     = rep(field_column,
-                                              nrow(combined_splits)),
-                                orders  = seq_len(nrow(combined_splits)))
-  rownames(res)   <- NULL
+  res <- data.frame(
+    options = combined_splits[, 1L],
+    values = combined_splits[, 2L],
+    grp = rep(
+      field_column,
+      nrow(combined_splits)
+    ),
+    orders = seq_len(nrow(combined_splits))
+  )
+  rownames(res) <- NULL
   return(res)
 }
 
@@ -154,48 +181,59 @@ dictionary_make_metadata <- function(x, field_column) {
 #' @examples
 #' test <- add_to_dictionary(
 #'   dictionary = readRDS(system.file("extdata", "test_dict.RDS",
-#'                        package = "cleanepi")),
-#'   option     = "ml",
-#'   value      = "male",
-#'   grp        = "gender",
-#'   order      = NULL
-#'  )
+#'     package = "cleanepi"
+#'   )),
+#'   option = "ml",
+#'   value = "male",
+#'   grp = "gender",
+#'   order = NULL
+#' )
 add_to_dictionary <- function(dictionary,
-                               option,
-                               value,
-                               grp,
-                               order = NULL) {
-  checkmate::assert_vector(option, min.len = 1L, null.ok = FALSE,
-                           any.missing = FALSE)
-  checkmate::assert_vector(value, min.len = 1L, null.ok = FALSE,
-                           any.missing = FALSE)
-  checkmate::assert_vector(grp, min.len = 1L, null.ok = FALSE,
-                           any.missing = FALSE)
-  checkmate::assert_numeric(order, any.missing = TRUE, lower = 1L,
-                            null.ok = TRUE)
+                              option,
+                              value,
+                              grp,
+                              order = NULL) {
+  checkmate::assert_vector(option,
+    min.len = 1L, null.ok = FALSE,
+    any.missing = FALSE
+  )
+  checkmate::assert_vector(value,
+    min.len = 1L, null.ok = FALSE,
+    any.missing = FALSE
+  )
+  checkmate::assert_vector(grp,
+    min.len = 1L, null.ok = FALSE,
+    any.missing = FALSE
+  )
+  checkmate::assert_numeric(order,
+    any.missing = TRUE, lower = 1L,
+    null.ok = TRUE
+  )
 
   # select the lines in the data dictionary where the column name is the same as
   # the value of the grp argument
-  max_order      <- max(dictionary[["orders"]])
+  max_order <- max(dictionary[["orders"]])
   tmp_dictionary <- dictionary %>%
     dplyr::filter(.data$grp == grp)
 
-  dictionary     <- dictionary %>%
+  dictionary <- dictionary %>%
     dplyr::filter(.data$grp != grp)
 
   # make the new order
-  new_order      <- order
+  new_order <- order
   if (is.null(order)) {
-    new_order    <- max_order + seq_along(option)
+    new_order <- max_order + seq_along(option)
   }
 
   # make the data frame with the new option
-  new_option     <- data.frame(options = option,
-                               values  = value,
-                               grp     = grp,
-                               orders  = new_order)
+  new_option <- data.frame(
+    options = option,
+    values = value,
+    grp = grp,
+    orders = new_order
+  )
   tmp_dictionary <- rbind(tmp_dictionary, new_option)
-  dictionary     <- rbind(dictionary, tmp_dictionary)
+  dictionary <- rbind(dictionary, tmp_dictionary)
   return(dictionary)
 }
 
@@ -208,14 +246,14 @@ add_to_dictionary <- function(dictionary,
 #' @keywords internal
 #'
 detect_misspelled_options <- function(data, dictionary) {
-  cols_to_modify  <- unique(dictionary[["grp"]])
-  outliers        <- list()
+  cols_to_modify <- unique(dictionary[["grp"]])
+  outliers <- list()
   for (col in cols_to_modify) {
     unique_values <- unique(data[[col]])[!is.na(unique(data[[col]]))]
-    temp_dict     <- dictionary %>%
+    temp_dict <- dictionary %>%
       dplyr::filter(.data$grp == col)
-    opts          <- c(temp_dict[["options"]], unique(temp_dict[["values"]]))
-    m             <- match(unique_values, opts)
+    opts <- c(temp_dict[["options"]], unique(temp_dict[["values"]]))
+    m <- match(unique_values, opts)
     if (anyNA(m)) {
       outliers[[col]] <- which(data[[col]] == unique_values[is.na(m)])
     }
@@ -234,8 +272,10 @@ detect_misspelled_options <- function(data, dictionary) {
 #'
 print_misspelled_values <- function(misspelled_options) {
   for (opts in names(misspelled_options)) {
-    message("\nDetected misspelled values at lines ",
-            paste(misspelled_options[[opts]], sep = ", "),
-            " of column '", opts, "'")
+    message(
+      "\nDetected misspelled values at lines ",
+      paste(misspelled_options[[opts]], sep = ", "),
+      " of column '", opts, "'"
+    )
   }
 }

--- a/R/find_and_remove_duplicates.R
+++ b/R/find_and_remove_duplicates.R
@@ -16,17 +16,17 @@
 #'
 #' @examples
 #' no_dups <- remove_duplicates(
-#'   data           = readRDS(system.file("extdata", "test_linelist.RDS",
-#'                                        package = "cleanepi")),
+#'   data = readRDS(system.file("extdata", "test_linelist.RDS",
+#'     package = "cleanepi"
+#'   )),
 #'   target_columns = "linelist_tags"
 #' )
 #' @importFrom rlang .data
 #'
 remove_duplicates <- function(data, target_columns = NULL) {
-
   # setting up the variables below to NULL to avoid linters
   report <- attr(data, "report")
-  dat    <- data
+  dat <- data
 
   # get the correct names in case some have been modified - see the
   # `retrieve_column_names()` function for more details
@@ -34,13 +34,13 @@ remove_duplicates <- function(data, target_columns = NULL) {
   target_columns <- get_target_column_names(dat, target_columns, cols = NULL)
 
   # find duplicates
-  dups       <- find_duplicates(dat, target_columns)
+  dups <- find_duplicates(dat, target_columns)
   tmp_report <- attr(dups, "report")
   if ("duplicated_rows" %in% names(tmp_report) &&
-      nrow(tmp_report[["duplicated_rows"]]) > 0L) {
-    dups     <- tmp_report[["duplicated_rows"]]
-    report   <- c(report, tmp_report)
-    dat      <- dat %>%
+    nrow(tmp_report[["duplicated_rows"]]) > 0L) {
+    dups <- tmp_report[["duplicated_rows"]]
+    report <- c(report, tmp_report)
+    dat <- dat %>%
       dplyr::mutate(row_id = seq_len(nrow(dat)))
   }
 
@@ -50,10 +50,10 @@ remove_duplicates <- function(data, target_columns = NULL) {
     dplyr::distinct_at({{ target_columns }}, .keep_all = TRUE)
 
   if ("duplicated_rows" %in% names(tmp_report) &&
-      nrow(tmp_report[["duplicated_rows"]]) > 0L) {
+    nrow(tmp_report[["duplicated_rows"]]) > 0L) {
     tmp_target_columns <- c("row_id", target_columns)
-    to_be_removed      <- suppressMessages(dplyr::anti_join(dups, dat) %>%
-        dplyr::select({{ tmp_target_columns }}))
+    to_be_removed <- suppressMessages(dplyr::anti_join(dups, dat) %>%
+      dplyr::select({{ tmp_target_columns }}))
     report[["removed_duplicates"]] <- to_be_removed
   }
 
@@ -86,8 +86,9 @@ remove_duplicates <- function(data, target_columns = NULL) {
 #'
 #' @examples
 #' dups <- find_duplicates(
-#'   data           = readRDS(system.file("extdata", "test_linelist.RDS",
-#'                                        package = "cleanepi")),
+#'   data = readRDS(system.file("extdata", "test_linelist.RDS",
+#'     package = "cleanepi"
+#'   )),
 #'   target_columns = c("dt_onset", "dt_report", "sex", "outcome")
 #' )
 #' @importFrom rlang .data
@@ -111,16 +112,22 @@ find_duplicates <- function(data, target_columns = NULL) {
     dplyr::select("row_id", "group_id", dplyr::everything())
 
   if (nrow(dups) > 0L) {
-    message("Found ", nrow(dups), " duplicated rows. Please consult the report",
-            " for more details.")
+    message(
+      "Found ", nrow(dups), " duplicated rows. Please consult the report",
+      " for more details."
+    )
     to_be_shown <- dups %>%
       dplyr::select(c("row_id", "group_id", {{ target_columns }}))
-    data <- add_to_report(x     = data,
-                          key   = "duplicated_rows",
-                          value = to_be_shown)
-    data <- add_to_report(x     = data,
-                          key   = "duplicates_checked_from",
-                          value = paste(target_columns, sep = ", "))
+    data <- add_to_report(
+      x = data,
+      key = "duplicated_rows",
+      value = to_be_shown
+    )
+    data <- add_to_report(
+      x = data,
+      key = "duplicates_checked_from",
+      value = paste(target_columns, sep = ", ")
+    )
   }
   return(data)
 }

--- a/R/print_report.R
+++ b/R/print_report.R
@@ -24,7 +24,9 @@
 #'
 #' # Perform data cleaning
 #' cleaned_data <- data %>%
-#'   standardize_column_names(keep = NULL, rename = c("DOB" = "dateOfBirth")) %>%
+#'   standardize_column_names(
+#'     keep = NULL, rename = c("DOB" = "dateOfBirth")
+#'   ) %>%
 #'   replace_missing_values(target_columns = NULL, na_strings = "-99") %>%
 #'   remove_constants(cutoff = 1.0) %>%
 #'   remove_duplicates(target_columns = NULL) %>%

--- a/R/print_report.R
+++ b/R/print_report.R
@@ -16,33 +16,40 @@
 #' \donttest{
 #' data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
 #' test_dictionary <- readRDS(system.file("extdata", "test_dictionary.RDS",
-#'                                        package = "cleanepi"))
+#'   package = "cleanepi"
+#' ))
 #'
 #' # scan through the data
 #' scan_res <- scan_data(data)
 #'
 #' # Perform data cleaning
 #' cleaned_data <- data %>%
-#'  standardize_column_names(keep = NULL, rename = c("DOB" = "dateOfBirth")) %>%
-#'  replace_missing_values(target_columns = NULL, na_strings = "-99") %>%
-#'  remove_constants(cutoff = 1.0) %>%
-#'  remove_duplicates(target_columns = NULL) %>%
-#'  standardize_dates(target_columns  = NULL,
-#'                    error_tolerance = 0.4,
-#'                    format          = NULL,
-#'                    timeframe   = as.Date(c("1973-05-29", "2023-05-29"))) %>%
-#'  check_subject_ids(target_columns = "study_id",
-#'                    prefix         = "PS",
-#'                    suffix         = "P2",
-#'                    range          = c(1L, 100L),
-#'                    nchar          = 7L) %>%
-#'  convert_to_numeric(target_columns = "sex", lang = "en") %>%
-#'  clean_using_dictionary(dictionary = test_dictionary)
+#'   standardize_column_names(keep = NULL, rename = c("DOB" = "dateOfBirth")) %>%
+#'   replace_missing_values(target_columns = NULL, na_strings = "-99") %>%
+#'   remove_constants(cutoff = 1.0) %>%
+#'   remove_duplicates(target_columns = NULL) %>%
+#'   standardize_dates(
+#'     target_columns = NULL,
+#'     error_tolerance = 0.4,
+#'     format = NULL,
+#'     timeframe = as.Date(c("1973-05-29", "2023-05-29"))
+#'   ) %>%
+#'   check_subject_ids(
+#'     target_columns = "study_id",
+#'     prefix = "PS",
+#'     suffix = "P2",
+#'     range = c(1L, 100L),
+#'     nchar = 7L
+#'   ) %>%
+#'   convert_to_numeric(target_columns = "sex", lang = "en") %>%
+#'   clean_using_dictionary(dictionary = test_dictionary)
 #'
 #' # add the data scanning result to the report
-#' cleaned_data <- add_to_report(x     = cleaned_data,
-#'                               key   = "scanning_result",
-#'                               value = scan_res)
+#' cleaned_data <- add_to_report(
+#'   x = cleaned_data,
+#'   key = "scanning_result",
+#'   value = scan_res
+#' )
 #'
 #' # save a report in the current directory using the previously-created objects
 #' print_report(
@@ -57,26 +64,26 @@
 #' @export
 #' @importFrom utils browseURL
 print_report <- function(data,
-                         report_title     = "{cleanepi} data cleaning report",
+                         report_title = "{cleanepi} data cleaning report",
                          output_file_name = NULL,
-                         format           = "html",
-                         print            = TRUE) {
-
+                         format = "html",
+                         print = TRUE) {
   # extract report and check whether any cleaning operation has been performed
-  report             <- attr(data, "report")
+  report <- attr(data, "report")
   stopifnot("No report associated with the input data." = !is.null(report))
 
   # generate output file and directory
-  timestamp_string   <- format(Sys.time(), "_%Y-%m-%d%_at_%H%M%S")
+  timestamp_string <- format(Sys.time(), "_%Y-%m-%d%_at_%H%M%S")
   if (is.null(output_file_name)) {
     output_file_name <- paste0("cleanepi_report_", timestamp_string)
   }
 
   # this ensures to add the logo to the report
   report[["report_title"]] <- report_title
-  man_path                 <- file.path("man", "figures")
-  report[["logo"]]         <- system.file(man_path, "logo.svg",
-                                          package = "cleanepi")
+  man_path <- file.path("man", "figures")
+  report[["logo"]] <- system.file(man_path, "logo.svg",
+    package = "cleanepi"
+  )
 
   # Temporarily copy Rmd file from package library into save_directory so that
   # intermediate files also get created there.
@@ -86,17 +93,20 @@ print_report <- function(data,
   withr::with_tempdir(
     {
       file.copy(
-        from      = system.file("rmarkdown", "templates", "printing-rmd",
-                                "skeleton", "skeleton.Rmd",
-                                package  = "cleanepi",
-                                mustWork = TRUE),
-        to        = getwd(),
+        from = system.file("rmarkdown", "templates", "printing-rmd",
+          "skeleton", "skeleton.Rmd",
+          package = "cleanepi",
+          mustWork = TRUE
+        ),
+        to = getwd(),
         overwrite = TRUE
       )
 
-      file_and_path  <- file.path(getwd(), paste0(output_file_name, ".html"))
-      stopifnot("Invalid format: Only 'html' format is currently supported." =
-                  format == "html")
+      file_and_path <- file.path(getwd(), paste0(output_file_name, ".html"))
+      stopifnot(
+        "Invalid format: Only 'html' format is currently supported." =
+          format == "html"
+      )
       message("Generating html report in ", getwd())
       rmarkdown::render(
         input       = file.path(getwd(), "skeleton.Rmd"),
@@ -106,8 +116,8 @@ print_report <- function(data,
         quiet       = TRUE
       )
     },
-    tmpdir  = tempdir(),
-    clean   = FALSE, # when TRUE, the folder is deleted and report is not
+    tmpdir = tempdir(),
+    clean = FALSE, # when TRUE, the folder is deleted and report is not
     # printed out
     fileext = "",
     pattern = "cleanepi_report_"

--- a/R/remove_constants.R
+++ b/R/remove_constants.R
@@ -25,11 +25,13 @@
 #' report <- attr(dat, "report")
 #' summary(report)
 remove_constants <- function(data, cutoff = 1L) {
-  checkmate::assert_number(cutoff, lower = 0.0, upper = 1.0, na.ok = FALSE,
-                           finite = TRUE, null.ok = FALSE)
-  report  <- attr(data, "report")
+  checkmate::assert_number(cutoff,
+    lower = 0.0, upper = 1.0, na.ok = FALSE,
+    finite = TRUE, null.ok = FALSE
+  )
+  report <- attr(data, "report")
   # remove the empty rows and columns
-  dat     <- data %>%
+  dat <- data %>%
     janitor::remove_empty(which = c("rows", "cols"), cutoff = cutoff)
 
   # report empty columns if found
@@ -48,8 +50,8 @@ remove_constants <- function(data, cutoff = 1L) {
   }
 
   # remove constant columns
-  data    <- dat
-  dat     <- data %>% janitor::remove_constant()
+  data <- dat
+  dat <- data %>% janitor::remove_constant()
   removed <- setdiff(colnames(data), names(dat))
   if (length(removed) > 0L) {
     add_this <- paste(removed, sep = ", ")

--- a/R/replace_missing_values.R
+++ b/R/replace_missing_values.R
@@ -1,4 +1,3 @@
-
 #' Replace missing values with `NA`
 #'
 #' @param data A data frame or linelist
@@ -18,10 +17,11 @@
 #'
 #' @examples
 #' cleaned_data <- replace_missing_values(
-#'   data           = readRDS(system.file("extdata", "test_df.RDS",
-#'                                        package = "cleanepi")),
+#'   data = readRDS(system.file("extdata", "test_df.RDS",
+#'     package = "cleanepi"
+#'   )),
 #'   target_columns = "sex",
-#'   na_strings     = "-99"
+#'   na_strings = "-99"
 #' )
 #'
 replace_missing_values <- function(data,
@@ -30,13 +30,13 @@ replace_missing_values <- function(data,
   # get the correct names in case some have been modified - see the
   # `retrieve_column_names()` function for more details
   target_columns <- retrieve_column_names(data, target_columns)
-  cols           <- get_target_column_names(data, target_columns, cols = NULL)
+  cols <- get_target_column_names(data, target_columns, cols = NULL)
 
   # get the indices of the columns that contain the missing value characters
   tmp <- data %>%
     dplyr::select(dplyr::all_of(cols))
   indices <- colSums(apply(tmp, 2, match, na_strings), na.rm = TRUE) > 0
-  cols    <- names(tmp)[indices]
+  cols <- names(tmp)[indices]
 
   # send a warning when none of the columns contains the provided missing value
   # string
@@ -44,16 +44,20 @@ replace_missing_values <- function(data,
     # replace missing values with NA
     data <- data %>%
       dplyr::mutate(dplyr::across(dplyr::all_of(cols), ~
-                                    dplyr::na_if(as.character(.x), na_strings)))
+        dplyr::na_if(as.character(.x), na_strings)))
 
     # make report
-    data <- add_to_report(x     = data,
-                          key   = "missing_values_replaced_at",
-                          value = paste(cols, sep = ", "))
+    data <- add_to_report(
+      x = data,
+      key = "missing_values_replaced_at",
+      value = paste(cols, sep = ", ")
+    )
   } else {
     warning("Could not detect missing value character!",
-            "\nPlease use the appropriate strings that represents the missing",
-            "values from your data.", call. = FALSE)
+      "\nPlease use the appropriate strings that represents the missing",
+      "values from your data.",
+      call. = FALSE
+    )
   }
 
   return(data)

--- a/R/standardize_date.R
+++ b/R/standardize_date.R
@@ -90,41 +90,51 @@
 #'
 #' # How to use standardize_dates()
 #' dat <- standardize_dates(
-#'   data            = readRDS(system.file("extdata", "test_df.RDS",
-#'                                         package = "cleanepi")),
-#'   target_columns  = "date_first_pcr_positive_test",
-#'   format          = NULL,
-#'   timeframe       = NULL,
+#'   data = readRDS(system.file("extdata", "test_df.RDS",
+#'     package = "cleanepi"
+#'   )),
+#'   target_columns = "date_first_pcr_positive_test",
+#'   format = NULL,
+#'   timeframe = NULL,
 #'   error_tolerance = 0.4,
-#'   orders          = list(world_named_months = c("Ybd", "dby"),
-#'                          world_digit_months = c("dmy", "Ymd"),
-#'                          US_formats         = c("Omdy", "YOmd")),
-#'   modern_excel    = TRUE
+#'   orders = list(
+#'     world_named_months = c("Ybd", "dby"),
+#'     world_digit_months = c("dmy", "Ymd"),
+#'     US_formats = c("Omdy", "YOmd")
+#'   ),
+#'   modern_excel = TRUE
 #' )
 standardize_dates <- function(data,
-                              target_columns  = NULL,
-                              format          = NULL,
-                              timeframe       = NULL,
+                              target_columns = NULL,
+                              format = NULL,
+                              timeframe = NULL,
                               error_tolerance = 0.5,
-                              orders          = list(
+                              orders = list(
                                 world_named_months = c("Ybd", "dby"),
                                 world_digit_months = c("dmy", "Ymd"),
                                 US_formats         = c("Omdy", "YOmd")
                               ),
-                              modern_excel    = TRUE) {
-
+                              modern_excel = TRUE) {
   checkmate::assert_data_frame(data, null.ok = FALSE, min.cols = 1L)
-  checkmate::assert_character(target_columns, null.ok = TRUE,
-                              any.missing = FALSE)
+  checkmate::assert_character(target_columns,
+    null.ok = TRUE,
+    any.missing = FALSE
+  )
   checkmate::assert_character(format, null.ok = TRUE, any.missing = FALSE)
-  checkmate::assert_date(timeframe, any.missing = FALSE,
-                         null.ok = TRUE, len = 2L, unique = TRUE)
-  checkmate::assert_numeric(error_tolerance, lower = 0L, upper = 1L,
-                            max.len = 2L,
-                            any.missing = FALSE, null.ok = TRUE)
+  checkmate::assert_date(timeframe,
+    any.missing = FALSE,
+    null.ok = TRUE, len = 2L, unique = TRUE
+  )
+  checkmate::assert_numeric(error_tolerance,
+    lower = 0L, upper = 1L,
+    max.len = 2L,
+    any.missing = FALSE, null.ok = TRUE
+  )
   checkmate::assert_list(orders, min.len = 1L, null.ok = FALSE)
-  checkmate::assert_logical(modern_excel, len = 1L, null.ok = FALSE,
-                            any.missing = FALSE)
+  checkmate::assert_logical(modern_excel,
+    len = 1L, null.ok = FALSE,
+    any.missing = FALSE
+  )
 
   if (!is.null(target_columns)) {
     # get the correct names in case some have been modified - see the
@@ -139,16 +149,20 @@ standardize_dates <- function(data,
       format <- date_match_format_and_column(target_columns, format)
       for (i in seq_along(target_columns)) {
         data[[target_columns[i]]] <- as.Date(data[[target_columns[i]]],
-                                             format = format[i])
+          format = format[i]
+        )
         # check for outliers and set them to NA
         data <- date_convert(data, target_columns[i], error_tolerance,
-                             timeframe = timeframe, orders = orders,
-                             modern_excel = modern_excel)
+          timeframe = timeframe, orders = orders,
+          modern_excel = modern_excel
+        )
       }
     } else {
       for (cols in target_columns) {
-        sep <- unique(as.character(unlist(lapply(data[[cols]],
-                                                 date_detect_separator))))
+        sep <- unique(as.character(unlist(lapply(
+          data[[cols]],
+          date_detect_separator
+        ))))
         # Guess the date format if it is not provided.
         # This returns NULL if the format is not resolved.
         if (length(sep) > 0L) {
@@ -160,15 +174,17 @@ standardize_dates <- function(data,
           data[[cols]] <- as.Date(data[[cols]], format = format)
         }
         data <- date_convert(data, cols, error_tolerance, timeframe,
-                             orders = orders, modern_excel = modern_excel)
+          orders = orders, modern_excel = modern_excel
+        )
       }
     }
   } else {
-    data     <- date_guess_convert(data,
-                                   error_tolerance = error_tolerance,
-                                   timeframe       = timeframe,
-                                   orders          = orders,
-                                   modern_excel    = modern_excel)
+    data <- date_guess_convert(data,
+      error_tolerance = error_tolerance,
+      timeframe       = timeframe,
+      orders          = orders,
+      modern_excel    = modern_excel
+    )
   }
 
   return(data)

--- a/R/standardize_subject_ids.R
+++ b/R/standardize_subject_ids.R
@@ -14,32 +14,43 @@
 #'
 #' @examples
 #' dat <- check_subject_ids(
-#'   data           = readRDS(system.file("extdata", "test_df.RDS",
-#'                                        package = "cleanepi")),
+#'   data = readRDS(system.file("extdata", "test_df.RDS",
+#'     package = "cleanepi"
+#'   )),
 #'   target_columns = "study_id",
-#'   prefix         = "PS",
-#'   suffix         = "P2",
-#'   range          = c(1, 100),
-#'   nchar          = 7
+#'   prefix = "PS",
+#'   suffix = "P2",
+#'   range = c(1, 100),
+#'   nchar = 7
 #' )
 #' @export
 check_subject_ids <- function(data,
                               target_columns,
-                              prefix         = NULL,
-                              suffix         = NULL,
-                              range          = NULL,
-                              nchar          = NULL) {
+                              prefix = NULL,
+                              suffix = NULL,
+                              range = NULL,
+                              nchar = NULL) {
   checkmate::assert_data_frame(data, null.ok = FALSE)
-  checkmate::assert_character(target_columns, null.ok = FALSE,
-                              any.missing = FALSE, len = 1L)
-  checkmate::assert_vector(prefix, min.len = 1L, null.ok = TRUE,
-                           any.missing = FALSE)
-  checkmate::assert_vector(suffix, min.len = 1L, null.ok = TRUE,
-                           any.missing = FALSE)
-  checkmate::assert_vector(range, any.missing = FALSE, min.len = 2L,
-                           null.ok = TRUE, unique = TRUE, max.len = 2L)
-  checkmate::assert_numeric(nchar, null.ok = TRUE, any.missing = FALSE,
-                            len = 1L)
+  checkmate::assert_character(target_columns,
+    null.ok = FALSE,
+    any.missing = FALSE, len = 1L
+  )
+  checkmate::assert_vector(prefix,
+    min.len = 1L, null.ok = TRUE,
+    any.missing = FALSE
+  )
+  checkmate::assert_vector(suffix,
+    min.len = 1L, null.ok = TRUE,
+    any.missing = FALSE
+  )
+  checkmate::assert_vector(range,
+    any.missing = FALSE, min.len = 2L,
+    null.ok = TRUE, unique = TRUE, max.len = 2L
+  )
+  checkmate::assert_numeric(nchar,
+    null.ok = TRUE, any.missing = FALSE,
+    len = 1L
+  )
 
   # get the correct names in case some have been modified - see the
   # `retrieve_column_names()` function for more details
@@ -51,13 +62,13 @@ check_subject_ids <- function(data,
   }
 
   # check for missing and duplicated ids
-  data       <- check_subject_ids_oness(data, target_columns)
+  data <- check_subject_ids_oness(data, target_columns)
 
   # we will use regular expressions to match on prefix and suffix
-  regex_match  <- paste0(
+  regex_match <- paste0(
     "^", paste(prefix, collapse = "|"), # starts with prefix
     ".*",
-    paste(suffix, collapse = "|"), "$"  # ends with suffix
+    paste(suffix, collapse = "|"), "$" # ends with suffix
   )
 
   bad_rows <- which(!grepl(regex_match, data[[target_columns]]))
@@ -66,9 +77,11 @@ check_subject_ids <- function(data,
   # specified range is not trivial. we use an approach where we parse numbers
   # only.
   if (!is.null(range)) {
-    numbers_in <- as.numeric(unlist(lapply(data[[target_columns]],
-                                           readr::parse_number)))
-    bad_rows   <- c(
+    numbers_in <- as.numeric(unlist(lapply(
+      data[[target_columns]],
+      readr::parse_number
+    )))
+    bad_rows <- c(
       bad_rows,
       which(!(numbers_in >= min(range) & numbers_in <= max(range)))
     )
@@ -81,16 +94,21 @@ check_subject_ids <- function(data,
 
   # remove the incorrect rows
   if (!is.null(bad_rows)) {
-    bad_rows     <- sort(unique(bad_rows))
-    tmp_report   <- data.frame(idx = bad_rows,
-                               ids = data[[target_columns]][bad_rows])
-    bad_rows     <- toString(bad_rows)
+    bad_rows <- sort(unique(bad_rows))
+    tmp_report <- data.frame(
+      idx = bad_rows,
+      ids = data[[target_columns]][bad_rows]
+    )
+    bad_rows <- toString(bad_rows)
     warning("Detected incorrect subject ids at lines: ", bad_rows,
-            "\nUse the correct_subject_ids() function to adjust them.\n",
-            call. = FALSE)
-    data         <- add_to_report(x     = data,
-                                  key   = "incorrect_subject_id",
-                                  value = tmp_report)
+      "\nUse the correct_subject_ids() function to adjust them.\n",
+      call. = FALSE
+    )
+    data <- add_to_report(
+      x = data,
+      key = "incorrect_subject_id",
+      value = tmp_report
+    )
   }
 
   return(data)
@@ -117,13 +135,14 @@ check_subject_ids <- function(data,
 #' @examples
 #' # detect the incorrect subject ids
 #' dat <- check_subject_ids(
-#'   data           = readRDS(system.file("extdata", "test_df.RDS",
-#'                                        package = "cleanepi")),
+#'   data = readRDS(system.file("extdata", "test_df.RDS",
+#'     package = "cleanepi"
+#'   )),
 #'   target_columns = "study_id",
-#'   prefix         = "PS",
-#'   suffix         = "P2",
-#'   range          = c(1, 100),
-#'   nchar          = 7
+#'   prefix = "PS",
+#'   suffix = "P2",
+#'   range = c(1, 100),
+#'   nchar = 7
 #' )
 #'
 #' # generate the correction table
@@ -139,22 +158,28 @@ check_subject_ids <- function(data,
 #'   correction_table = correction_table
 #' )
 correct_subject_ids <- function(data, target_columns, correction_table) {
-  checkmate::assert_data_frame(correction_table, any.missing = FALSE,
-                               min.rows = 1L, ncols = 2L, null.ok = FALSE,
-                               col.names = "named")
+  checkmate::assert_data_frame(correction_table,
+    any.missing = FALSE,
+    min.rows = 1L, ncols = 2L, null.ok = FALSE,
+    col.names = "named"
+  )
   checkmate::assert_names(names(correction_table),
-                          identical.to = c("from", "to"))
+    identical.to = c("from", "to")
+  )
 
-  stopifnot("Some ids in the correction table were not found in the input data"
-            = all(correction_table[["from"]] %in% data[[target_columns]]))
+  stopifnot(
+    "Some ids in the correction table were not found in the input data" = all(correction_table[["from"]] %in% data[[target_columns]])
+  )
 
   # perform the substitution
-  idx                         <- match(correction_table[["from"]],
-                                       data[[target_columns]])
+  idx <- match(
+    correction_table[["from"]],
+    data[[target_columns]]
+  )
   data[[target_columns]][idx] <- correction_table[["to"]]
 
   # check whether substitution did not introduce any duplicate
-  data                        <- check_subject_ids_oness(data, target_columns)
+  data <- check_subject_ids_oness(data, target_columns)
 
   return(data)
 }
@@ -171,23 +196,29 @@ correct_subject_ids <- function(data, target_columns, correction_table) {
 check_subject_ids_oness <- function(data, id_col_name) {
   # check for missing values in ID column
   if (anyNA(data[[id_col_name]])) {
-    idx                <- which(is.na(data[[id_col_name]]))
+    idx <- which(is.na(data[[id_col_name]]))
     warning("\nMissing values found on ID column in lines: ",
-            paste(idx, sep = ", "), call. = FALSE)
-    data <- add_to_report(x     = data,
-                          key   = "missing_ids",
-                          value = paste(idx, sep = ", "))
+      paste(idx, sep = ", "),
+      call. = FALSE
+    )
+    data <- add_to_report(
+      x = data,
+      key = "missing_ids",
+      value = paste(idx, sep = ", ")
+    )
   }
 
   # check for duplicates ID column
-  duplicated_ids       <- find_duplicates(data, id_col_name)
-  tmp_report           <- attr(duplicated_ids, "report")
+  duplicated_ids <- find_duplicates(data, id_col_name)
+  tmp_report <- attr(duplicated_ids, "report")
   if (!is.null(tmp_report) && "duplicated_rows" %in% names(tmp_report) &&
-      nrow(tmp_report[["duplicated_rows"]]) > 0L) {
-    dups               <- tmp_report[["duplicated_rows"]]
-    data               <- add_to_report(x     = data,
-                                        key   = "duplicated_ids",
-                                        value = dups)
+    nrow(tmp_report[["duplicated_rows"]]) > 0L) {
+    dups <- tmp_report[["duplicated_rows"]]
+    data <- add_to_report(
+      x = data,
+      key = "duplicated_ids",
+      value = dups
+    )
   }
 
   return(data)

--- a/R/standardize_subject_ids.R
+++ b/R/standardize_subject_ids.R
@@ -168,7 +168,8 @@ correct_subject_ids <- function(data, target_columns, correction_table) {
   )
 
   stopifnot(
-    "Some ids in the correction table were not found in the input data" = all(correction_table[["from"]] %in% data[[target_columns]])
+    "Some ids in correction table not found in input data" =
+      all(correction_table[["from"]] %in% data[[target_columns]])
   )
 
   # perform the substitution

--- a/R/utils.R
+++ b/R/utils.R
@@ -81,12 +81,14 @@ get_sum <- function(x) {
 #' @examples
 #' # scan through the data
 #' scan_res <- scan_data(data = readRDS(system.file("extdata", "test_df.RDS",
-#'                                                  package = "cleanepi")))
+#'   package = "cleanepi"
+#' )))
 #'
 #' # Perform data cleaning
 #' cleaned_data <- clean_data(
-#'   data   = readRDS(system.file("extdata", "test_df.RDS",
-#'                                package = "cleanepi")),
+#'   data = readRDS(system.file("extdata", "test_df.RDS",
+#'     package = "cleanepi"
+#'   )),
 #'   params = list(
 #'     to_numeric = list(target_columns = "sex", lang = "en"),
 #'     dictionary = NULL
@@ -94,16 +96,20 @@ get_sum <- function(x) {
 #' )
 #'
 #' # add the data scanning result to the report
-#' cleaned_data <- add_to_report(x     = cleaned_data,
-#'                               key   = "scanning_result",
-#'                               value = scan_res)
+#' cleaned_data <- add_to_report(
+#'   x = cleaned_data,
+#'   key = "scanning_result",
+#'   value = scan_res
+#' )
 #'
 add_to_report <- function(x, key, value = NULL) {
   checkmate::assert_data_frame(x, min.rows = 1L, min.cols = 1L, null.ok = FALSE)
-  checkmate::assert_character(key, any.missing = FALSE, len = 1L,
-                              null.ok = FALSE)
-  report                    <- attr(x, "report")
-  report[[key]]             <- value
+  checkmate::assert_character(key,
+    any.missing = FALSE, len = 1L,
+    null.ok = FALSE
+  )
+  report <- attr(x, "report")
+  report[[key]] <- value
   attr(x, which = "report") <- report
   return(x)
 }
@@ -127,17 +133,21 @@ get_target_column_names <- function(data, target_columns, cols) {
 
   # extract column names if target_columns is a vector of column names
   if (length(target_columns) == 1L && target_columns != "linelist_tags") {
-    idx            <- match(target_columns, names(data))
-    stopifnot("Could not find some specified target column names" =
-                !anyNA(idx))
+    idx <- match(target_columns, names(data))
+    stopifnot(
+      "Could not find some specified target column names" =
+        !anyNA(idx)
+    )
     target_columns <- names(data)[idx]
   }
 
   # extract column names if target_columns is a vector of column indexes
   if (is.numeric(target_columns)) {
-    index          <- seq_along(data)
-    stopifnot("Incorrect vector of column name indices provided!" =
-                all(target_columns %in% index))
+    index <- seq_along(data)
+    stopifnot(
+      "Incorrect vector of column name indices provided!" =
+        all(target_columns %in% index)
+    )
     target_columns <- names(data)[target_columns]
   }
 
@@ -148,17 +158,19 @@ get_target_column_names <- function(data, target_columns, cols) {
               column names if you are dealing with a data frame" =
         inherits(data, "linelist")
     )
-    original_tags  <- linelist::tags(data)
+    original_tags <- linelist::tags(data)
     target_columns <- as.character(original_tags)
   }
 
   # check whether target columns are part of the empty or constant columns
   if (!is.null(cols)) {
-    idx              <- match(cols, target_columns)
+    idx <- match(cols, target_columns)
     if (length(idx) > 0L) {
       target_columns <- target_columns[-idx]
-      stopifnot("All specified columns are either constant or empty." =
-                  length(target_columns) > 0L)
+      stopifnot(
+        "All specified columns are either constant or empty." =
+          length(target_columns) > 0L
+      )
     }
   }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -85,23 +85,27 @@ The main function in **{{ packagename }}** is `clean_data(),` which internally m
 ```{r eval=TRUE}
 # READING IN THE TEST DATASET
 test_data <- readRDS(system.file("extdata", "test_df.RDS",
-                                 package = "cleanepi"))
+  package = "cleanepi"
+))
 ```
 
 ```{r echo=FALSE, eval=TRUE}
 test_data %>%
   kableExtra::kbl() %>%
   kableExtra::kable_paper("striped", font_size = 14, full_width = TRUE) %>%
-  kableExtra::scroll_box(height = "200px", width = "100%",
-                         box_css = "border: 1px solid #ddd; padding: 5px; ",
-                         extra_css = NULL,
-                         fixed_thead = TRUE)
+  kableExtra::scroll_box(
+    height = "200px", width = "100%",
+    box_css = "border: 1px solid #ddd; padding: 5px; ",
+    extra_css = NULL,
+    fixed_thead = TRUE
+  )
 ```
 
 ```{r eval=TRUE}
 # READING IN THE DATA DICTIONARY
 test_dictionary <- readRDS(system.file("extdata", "test_dictionary.RDS",
-                                       package = "cleanepi"))
+  package = "cleanepi"
+))
 ```
 
 ```{r echo=FALSE, eval=TRUE}
@@ -112,34 +116,44 @@ test_dictionary %>%
 
 ```{r eval=TRUE}
 # DEFINING THE CLEANING PARAMETERS
-use_na                  <- list(target_columns = NULL, na_strings = "-99")
-remove_duplicates       <- list(target_columns   = NULL)
-standardize_dates       <- list(target_columns  = NULL,
-                                error_tolerance = 0.4,
-                                format          = NULL,
-                                timeframe       = as.Date(c("1973-05-29",
-                                                            "2023-05-29")),
-                                modern_excel    = TRUE,
-                                orders          = list(
-                                  world_named_months = c("Ybd", "dby"),
-                                  world_digit_months = c("dmy", "Ymd"),
-                                  US_formats         = c("Omdy", "YOmd")
-                                ))
-standardize_subject_ids <- list(target_columns = "study_id",
-                                prefix         = "PS",
-                                suffix         = "P2",
-                                range          = c(1, 100),
-                                nchar          = 7)
-remove_cte              <- list(cutoff = 1)
-standardize_col_names   <- list(keep   = "date.of.admission",
-                                rename = c(DOB = "dateOfBirth"))
-to_numeric              <- list(target_columns = "sex",
-                                lang           = "en")
+use_na <- list(target_columns = NULL, na_strings = "-99")
+remove_duplicates <- list(target_columns = NULL)
+standardize_dates <- list(
+  target_columns = NULL,
+  error_tolerance = 0.4,
+  format = NULL,
+  timeframe = as.Date(c(
+    "1973-05-29",
+    "2023-05-29"
+  )),
+  modern_excel = TRUE,
+  orders = list(
+    world_named_months = c("Ybd", "dby"),
+    world_digit_months = c("dmy", "Ymd"),
+    US_formats         = c("Omdy", "YOmd")
+  )
+)
+standardize_subject_ids <- list(
+  target_columns = "study_id",
+  prefix = "PS",
+  suffix = "P2",
+  range = c(1, 100),
+  nchar = 7
+)
+remove_cte <- list(cutoff = 1)
+standardize_col_names <- list(
+  keep = "date.of.admission",
+  rename = c(DOB = "dateOfBirth")
+)
+to_numeric <- list(
+  target_columns = "sex",
+  lang = "en"
+)
 
 params <- list(
   standardize_column_names = standardize_col_names,
   remove_constants         = remove_cte,
-  replace_missing_values   = use_na, 
+  replace_missing_values   = use_na,
   remove_duplicates        = remove_duplicates,
   standardize_dates        = standardize_dates,
   standardize_subject_ids  = standardize_subject_ids,
@@ -161,10 +175,12 @@ cleaned_data <- clean_data(
 cleaned_data %>%
   kableExtra::kbl() %>%
   kableExtra::kable_paper("striped", font_size = 14, full_width = FALSE) %>%
-  kableExtra::scroll_box(height = "200px", width = "100%",
-                         box_css = "border: 1px solid #ddd; padding: 5px; ",
-                         extra_css = NULL,
-                         fixed_thead = TRUE)
+  kableExtra::scroll_box(
+    height = "200px", width = "100%",
+    box_css = "border: 1px solid #ddd; padding: 5px; ",
+    extra_css = NULL,
+    fixed_thead = TRUE
+  )
 ```
 
 ```{r eval=TRUE}

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ function.
 ``` r
 # READING IN THE TEST DATASET
 test_data <- readRDS(system.file("extdata", "test_df.RDS",
-                                 package = "cleanepi"))
+  package = "cleanepi"
+))
 ```
 
 <div style="border: 1px solid #ddd; padding: 0px; overflow-y: scroll; height:200px; overflow-x: scroll; width:100%; ">
@@ -393,7 +394,8 @@ Mar 03, 2021
 ``` r
 # READING IN THE DATA DICTIONARY
 test_dictionary <- readRDS(system.file("extdata", "test_dictionary.RDS",
-                                       package = "cleanepi"))
+  package = "cleanepi"
+))
 ```
 
 <table class=" lightable-paper lightable-striped" style="font-size: 14px; font-family: &quot;Arial Narrow&quot;, arial, helvetica, sans-serif; margin-left: auto; margin-right: auto;">
@@ -447,34 +449,44 @@ sex
 
 ``` r
 # DEFINING THE CLEANING PARAMETERS
-use_na                  <- list(target_columns = NULL, na_strings = "-99")
-remove_duplicates       <- list(target_columns   = NULL)
-standardize_dates       <- list(target_columns  = NULL,
-                                error_tolerance = 0.4,
-                                format          = NULL,
-                                timeframe       = as.Date(c("1973-05-29",
-                                                            "2023-05-29")),
-                                modern_excel    = TRUE,
-                                orders          = list(
-                                  world_named_months = c("Ybd", "dby"),
-                                  world_digit_months = c("dmy", "Ymd"),
-                                  US_formats         = c("Omdy", "YOmd")
-                                ))
-standardize_subject_ids <- list(target_columns = "study_id",
-                                prefix         = "PS",
-                                suffix         = "P2",
-                                range          = c(1, 100),
-                                nchar          = 7)
-remove_cte              <- list(cutoff = 1)
-standardize_col_names   <- list(keep   = "date.of.admission",
-                                rename = c(DOB = "dateOfBirth"))
-to_numeric              <- list(target_columns = "sex",
-                                lang           = "en")
+use_na <- list(target_columns = NULL, na_strings = "-99")
+remove_duplicates <- list(target_columns = NULL)
+standardize_dates <- list(
+  target_columns = NULL,
+  error_tolerance = 0.4,
+  format = NULL,
+  timeframe = as.Date(c(
+    "1973-05-29",
+    "2023-05-29"
+  )),
+  modern_excel = TRUE,
+  orders = list(
+    world_named_months = c("Ybd", "dby"),
+    world_digit_months = c("dmy", "Ymd"),
+    US_formats         = c("Omdy", "YOmd")
+  )
+)
+standardize_subject_ids <- list(
+  target_columns = "study_id",
+  prefix = "PS",
+  suffix = "P2",
+  range = c(1, 100),
+  nchar = 7
+)
+remove_cte <- list(cutoff = 1)
+standardize_col_names <- list(
+  keep = "date.of.admission",
+  rename = c(DOB = "dateOfBirth")
+)
+to_numeric <- list(
+  target_columns = "sex",
+  lang = "en"
+)
 
 params <- list(
   standardize_column_names = standardize_col_names,
   remove_constants         = remove_cte,
-  replace_missing_values   = use_na, 
+  replace_missing_values   = use_na,
   remove_duplicates        = remove_duplicates,
   standardize_dates        = standardize_dates,
   standardize_subject_ids  = standardize_subject_ids,
@@ -498,7 +510,7 @@ cleaned_data <- clean_data(
 #> checking subject IDs format
 #> Warning: Detected incorrect subject ids at lines: 3, 5, 7
 #> Use the correct_subject_ids() function to adjust them.
-#> convertingsexeninto numeric
+#> converting sex, en into numeric
 #> performing dictionary-based cleaning
 ```
 

--- a/data-raw/common_na_strings.R
+++ b/data-raw/common_na_strings.R
@@ -3,9 +3,11 @@
 ## strings that are frequently encountered. This will be updated as time goes
 ## based on user's suggestions.
 
-common_na_strings <- c(naniar::common_na_strings,
-                       "not available", "Not Available", "NOt available",
-                       "not avail", "Not Avail", "nan", "NAN", "not a number",
-                       "Not A Number")
+common_na_strings <- c(
+  naniar::common_na_strings,
+  "not available", "Not Available", "NOt available",
+  "not avail", "Not Avail", "nan", "NAN", "not a number",
+  "Not A Number"
+)
 
 usethis::use_data(common_na_strings, overwrite = TRUE)

--- a/tests/testthat/test-check_date_sequence.R
+++ b/tests/testthat/test-check_date_sequence.R
@@ -1,74 +1,91 @@
 test_that("is_date_sequence_ordered works as expected", {
-  x   <- as.Date(c("2023-10-02", "2023-10-10", "2023-10-20"))
+  x <- as.Date(c("2023-10-02", "2023-10-10", "2023-10-20"))
   res <- is_date_sequence_ordered(x)
   expect_true(res)
 })
 
 test_that("is_date_sequence_ordered works as expected", {
-  x   <- as.Date(c("2023-10-02", "2023-10-20", "2023-10-10"))
+  x <- as.Date(c("2023-10-02", "2023-10-20", "2023-10-10"))
   res <- is_date_sequence_ordered(x)
   expect_false(res)
 })
 
 # import the data
 data <- readRDS(system.file("extdata", "test_df.RDS",
-                            package = "cleanepi"))
+  package = "cleanepi"
+))
 
 # standardize the date values
 data <- data %>%
   standardize_dates(
-    target_columns  = c("date_first_pcr_positive_test",
-                        "date.of.admission"),
+    target_columns = c(
+      "date_first_pcr_positive_test",
+      "date.of.admission"
+    ),
     error_tolerance = 0.4,
-    format          = NULL,
-    timeframe       = NULL
+    format = NULL,
+    timeframe = NULL
   )
 
 test_that("check_date_sequence sends a warning when incorrect column nams are
           found", {
-            expect_warning(
-              check_date_sequence(
-                data           = data,
-                target_columns = c("date_first_pcr_positive_test",
-                                   "date.of.admission", "fake_name")
-              ),
-              regexp = cat("Removing unrecognised column name: fake_name")
-            )
+  expect_warning(
+    check_date_sequence(
+      data = data,
+      target_columns = c(
+        "date_first_pcr_positive_test",
+        "date.of.admission", "fake_name"
+      )
+    ),
+    regexp = cat("Removing unrecognised column name: fake_name")
+  )
 
-            expect_warning(
-              check_date_sequence(
-                data           = data,
-                target_columns = c("date_first_pcr_positive_test",
-                                   "date.of.admission")              ),
-              regexp = cat("Detected 2 incorrect date sequences at
+  expect_warning(
+    check_date_sequence(
+      data = data,
+      target_columns = c(
+        "date_first_pcr_positive_test",
+        "date.of.admission"
+      )
+    ),
+    regexp = cat("Detected 2 incorrect date sequences at
                            line(s): 6, 8")
-            )
+  )
 
-            expect_error(
-              check_date_sequence(
-                data           = data,
-                target_columns = c("date_first_pcr_positive_test",
-                                   "fake_name")),
-              regexp = cat("At least 2 event dates are required!")
-            )
+  expect_error(
+    check_date_sequence(
+      data = data,
+      target_columns = c(
+        "date_first_pcr_positive_test",
+        "fake_name"
+      )
+    ),
+    regexp = cat("At least 2 event dates are required!")
+  )
 })
 
 test_that("check_date_sequence works as expected when target_column is provided
           as a vector", {
-              good_date_sequence <- check_date_sequence(
-                data           = data,
-                target_columns = c("date_first_pcr_positive_test",
-                                   "date.of.admission")
-              )
-              report <- attr(good_date_sequence, "report")
-              expect_s3_class(good_date_sequence, "data.frame")
-              expect_identical(nrow(good_date_sequence), 10L)
-              expect_type(report, "list")
-              expect_named(report, "incorrect_date_sequence")
-              expect_s3_class(report[["incorrect_date_sequence"]], "data.frame")
-              expect_identical(nrow(report[["incorrect_date_sequence"]]), 2L)
-              expect_identical(ncol(report[["incorrect_date_sequence"]]), 2L)
-              expect_identical(names(report[["incorrect_date_sequence"]]),
-                               c("date_first_pcr_positive_test",
-                                 "date.of.admission"))
+  good_date_sequence <- check_date_sequence(
+    data = data,
+    target_columns = c(
+      "date_first_pcr_positive_test",
+      "date.of.admission"
+    )
+  )
+  report <- attr(good_date_sequence, "report")
+  expect_s3_class(good_date_sequence, "data.frame")
+  expect_identical(nrow(good_date_sequence), 10L)
+  expect_type(report, "list")
+  expect_named(report, "incorrect_date_sequence")
+  expect_s3_class(report[["incorrect_date_sequence"]], "data.frame")
+  expect_identical(nrow(report[["incorrect_date_sequence"]]), 2L)
+  expect_identical(ncol(report[["incorrect_date_sequence"]]), 2L)
+  expect_identical(
+    names(report[["incorrect_date_sequence"]]),
+    c(
+      "date_first_pcr_positive_test",
+      "date.of.admission"
+    )
+  )
 })

--- a/tests/testthat/test-clean_data.R
+++ b/tests/testthat/test-clean_data.R
@@ -1,9 +1,10 @@
-
 test_data <- readRDS(system.file("extdata", "test_df.RDS",
-                                 package = "cleanepi"))
+  package = "cleanepi"
+))
 
 test_dictionary <- readRDS(system.file("extdata", "test_dictionary.RDS",
-                                       package = "cleanepi"))
+  package = "cleanepi"
+))
 
 test_that("clean_data works as expected with the default parameters", {
   cleaned_data <- clean_data(
@@ -16,26 +17,36 @@ test_that("clean_data works as expected with the default parameters", {
 })
 
 # DEFINING THE CLEANING PARAMETERS
-use_na                  <- list(target_columns = NULL, na_strings = "-99")
-standardize_col_names   <- list(keep = NULL, rename = NULL)
-remove_duplicates       <- list(target_columns   = NULL)
-standardize_dates       <- list(target_columns  = NULL,
-                                error_tolerance = 0.4,
-                                format          = NULL,
-                                timeframe       = as.Date(c("1973-05-29",
-                                                            "2023-05-29")),
-                                orders = list(named_months = c("Ybd", "dby"),
-                                              digit_months = c("dmy", "Ymd"),
-                                              US_formats = c("Omdy", "YOmd")),
-                                modern_excel = TRUE)
-standardize_subject_ids <- list(target_columns = "study_id",
-                                prefix         = "PS",
-                                suffix         = "P2",
-                                range          = c(1L, 100L),
-                                nchar          = 7L)
-to_numeric              <- list(target_columns = "sex",
-                                lang           = "en")
-check_date_sequence     <- list(
+use_na <- list(target_columns = NULL, na_strings = "-99")
+standardize_col_names <- list(keep = NULL, rename = NULL)
+remove_duplicates <- list(target_columns = NULL)
+standardize_dates <- list(
+  target_columns = NULL,
+  error_tolerance = 0.4,
+  format = NULL,
+  timeframe = as.Date(c(
+    "1973-05-29",
+    "2023-05-29"
+  )),
+  orders = list(
+    named_months = c("Ybd", "dby"),
+    digit_months = c("dmy", "Ymd"),
+    US_formats = c("Omdy", "YOmd")
+  ),
+  modern_excel = TRUE
+)
+standardize_subject_ids <- list(
+  target_columns = "study_id",
+  prefix = "PS",
+  suffix = "P2",
+  range = c(1L, 100L),
+  nchar = 7L
+)
+to_numeric <- list(
+  target_columns = "sex",
+  lang = "en"
+)
+check_date_sequence <- list(
   target_columns = c("date_first_pcr_positive_test", "date.of.admission")
 )
 params <- list(
@@ -67,15 +78,19 @@ test_that("cleaned_data works in a pipable way", {
     replace_missing_values(target_columns = NULL, na_strings = "-99") %>%
     remove_constants(cutoff = 1.0) %>%
     remove_duplicates(target_columns = NULL) %>%
-    standardize_dates(target_columns  = NULL,
-                      error_tolerance = 0.4,
-                      format          = NULL,
-                      timeframe     = as.Date(c("1973-05-29", "2023-05-29"))) %>%
-    check_subject_ids(target_columns = "study_id",
-                      prefix         = "PS",
-                      suffix         = "P2",
-                      range          = c(1L, 100L),
-                      nchar          = 7L) %>%
+    standardize_dates(
+      target_columns = NULL,
+      error_tolerance = 0.4,
+      format = NULL,
+      timeframe = as.Date(c("1973-05-29", "2023-05-29"))
+    ) %>%
+    check_subject_ids(
+      target_columns = "study_id",
+      prefix = "PS",
+      suffix = "P2",
+      range = c(1L, 100L),
+      nchar = 7L
+    ) %>%
     convert_to_numeric(target_columns = "sex", lang = "en") %>%
     clean_using_dictionary(dictionary = test_dictionary)
 
@@ -87,15 +102,19 @@ test_that("cleaned_data works in a pipable way", {
 
 test_that("cleaned_data works in a pipable way even when old column names are
           used", {
-            cleaned_data <- test_data %>%
-              standardize_column_names(keep = NULL,
-                                       rename = c(DOB = "dateOfBirth")) %>%
-              standardize_dates(target_columns = c("dateOfBirth",
-                                                   "date_of_admission"))
-            expect_s3_class(cleaned_data, "data.frame")
-            expect_identical(nrow(cleaned_data), 10L)
-            expect_identical(class(cleaned_data[["DOB"]]), "Date")
-            expect_identical(class(cleaned_data[["date_of_admission"]]), "Date")
+  cleaned_data <- test_data %>%
+    standardize_column_names(
+      keep = NULL,
+      rename = c(DOB = "dateOfBirth")
+    ) %>%
+    standardize_dates(target_columns = c(
+      "dateOfBirth",
+      "date_of_admission"
+    ))
+  expect_s3_class(cleaned_data, "data.frame")
+  expect_identical(nrow(cleaned_data), 10L)
+  expect_identical(class(cleaned_data[["DOB"]]), "Date")
+  expect_identical(class(cleaned_data[["date_of_admission"]]), "Date")
 })
 
 test_that("clean_data fails as expected", {
@@ -107,10 +126,13 @@ test_that("clean_data fails as expected", {
 
   expect_error(
     test_data %>%
-      standardize_column_names(keep = NULL,
-                               rename = "dateOfBirth = DOB") %>%
-      standardize_dates(target_columns = c("dateOfBirth", "fake_column_name",
-                                           "date_of_admission"))
+      standardize_column_names(
+        keep = NULL,
+        rename = "dateOfBirth = DOB"
+      ) %>%
+      standardize_dates(target_columns = c(
+        "dateOfBirth", "fake_column_name",
+        "date_of_admission"
+      ))
   )
 })
-

--- a/tests/testthat/test-clean_data_helpers.R
+++ b/tests/testthat/test-clean_data_helpers.R
@@ -1,11 +1,14 @@
 test_that("scan_data works", {
   scan_result <- scan_data(
     data = readRDS(system.file("extdata", "messy_data.RDS",
-                               package = "cleanepi"))
+      package = "cleanepi"
+    ))
   )
   expect_s3_class(scan_result, "data.frame")
-  expect_named(scan_result, c("Field_names", "missing", "numeric", "date",
-                              "character", "logical"))
+  expect_named(scan_result, c(
+    "Field_names", "missing", "numeric", "date",
+    "character", "logical"
+  ))
   expect_identical(ncol(scan_result), 6L)
   expect_identical(nrow(scan_result), 9L)
 })

--- a/tests/testthat/test-column_name_standardization.R
+++ b/tests/testthat/test-column_name_standardization.R
@@ -1,21 +1,25 @@
 test_that("standardize_column_names works with rename argument", {
   cleaned_data <- standardize_column_names(
-    data   = readRDS(system.file("extdata", "test_df.RDS",
-                                 package = "cleanepi")),
+    data = readRDS(system.file("extdata", "test_df.RDS",
+      package = "cleanepi"
+    )),
     rename = c(DOB = "dateOfBirth", gender = "sex")
   )
   expect_s3_class(cleaned_data, "data.frame")
-  expect_named(cleaned_data, expected = c("study_id", "event_name",
-                                          "country_code", "country_name",
-                                          "date_of_admission", "DOB",
-                                          "date_first_pcr_positive_test",
-                                          "gender"))
+  expect_named(cleaned_data, expected = c(
+    "study_id", "event_name",
+    "country_code", "country_name",
+    "date_of_admission", "DOB",
+    "date_first_pcr_positive_test",
+    "gender"
+  ))
 })
 test_that("standardize_column_names fails when rename argument contains existing column names", {
   expect_error(
     standardize_column_names(
-      data   = readRDS(system.file("extdata", "test_df.RDS",
-                                   package = "cleanepi")),
+      data = readRDS(system.file("extdata", "test_df.RDS",
+        package = "cleanepi"
+      )),
       rename = c(DOB = "dateOfBirth", dateOfBirth = "sex")
     ),
     regexp = cat("Replace column names already exists")
@@ -31,10 +35,13 @@ test_that("standardize_column_names works with keep argument", {
   )
   expect_s3_class(cleaned_data, "data.frame")
   expect_named(cleaned_data,
-               expected = c("study_id", "event_name", "country_code",
-                            "country_name", "date.of.admission",
-                            "date_of_birth", "date_first_pcr_positive_test",
-                            "sex"))
+    expected = c(
+      "study_id", "event_name", "country_code",
+      "country_name", "date.of.admission",
+      "date_of_birth", "date_first_pcr_positive_test",
+      "sex"
+    )
+  )
 
   cleaned_data <- standardize_column_names(
     data = readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi")),
@@ -42,17 +49,20 @@ test_that("standardize_column_names works with keep argument", {
   )
   expect_s3_class(cleaned_data, "data.frame")
   expect_named(cleaned_data,
-               expected = c("study_id", "event_name", "country_code",
-                            "country_name", "date.of.admission",
-                            "dateOfBirth", "date_first_pcr_positive_test",
-                            "sex"))
+    expected = c(
+      "study_id", "event_name", "country_code",
+      "country_name", "date.of.admission",
+      "dateOfBirth", "date_first_pcr_positive_test",
+      "sex"
+    )
+  )
 })
 
 test_that("standardize_column_names works with all argument", {
   cleaned_data <- standardize_column_names(
-    data  = readRDS(system.file("extdata", "test_df.RDS",package = "cleanepi")),
+    data = readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi")),
     rename = c(DOB = "dateOfBirth", gender = "sex"),
-    keep   = "date.of.admission"
+    keep = "date.of.admission"
   )
   expect_s3_class(cleaned_data, "data.frame")
   expect_named(cleaned_data, expected = c(
@@ -68,10 +78,11 @@ test_that("standardize_column_names fails when 'linelist_tags' is provided when
           dealing with a data frame", {
   expect_error(
     standardize_column_names(
-      data   = readRDS(system.file("extdata", "test_df.RDS",
-                                   package = "cleanepi")),
+      data = readRDS(system.file("extdata", "test_df.RDS",
+        package = "cleanepi"
+      )),
       rename = c(DOB = "dateOfBirth", gender = "sex"),
-      keep   = "linelist_tags"
+      keep = "linelist_tags"
     ),
     regexp = cat("Assertion on',keep,'failed: usage of 'linelist_tags'
                             is only reserved for 'linelist' type of data.")
@@ -82,10 +93,11 @@ test_that("standardize_column_names fails when wrong column names are
           specified", {
   expect_error(
     standardize_column_names(
-      data   = readRDS(system.file("extdata", "test_df.RDS",
-                                   package = "cleanepi")),
+      data = readRDS(system.file("extdata", "test_df.RDS",
+        package = "cleanepi"
+      )),
       rename = c(DOB = "dateOfBirth", gender = "fake_name"),
-      keep   = NULL
+      keep = NULL
     ),
     regexp = cat("Assertion on',keep or rename,'failed: Only the
                            column names from the input data can be renamed or

--- a/tests/testthat/test-convert_to_numeric.R
+++ b/tests/testthat/test-convert_to_numeric.R
@@ -22,29 +22,29 @@ test_that("convert_to_numeric works", {
 
 test_that("convert_to_numeric sends a warning when no column is provided and
           scan_data() does not find a target column", {
-            expect_warning(
-              convert_to_numeric(
-                data           = data,
-                target_columns = NULL
-              ),
-              regexp = cat("'gender' column has similar number of numeric and
+  expect_warning(
+    convert_to_numeric(
+      data           = data,
+      target_columns = NULL
+    ),
+    regexp = cat("'gender' column has similar number of numeric and
                            character values.")
-            )
-          })
+  )
+})
 
 test_that("convert_to_numeric returns NA when the specified language is not
           appropriate.", {
-            dat <- data[1L:10L, ]
-            idx <- which(is.na(suppressWarnings(as.numeric(dat$age))))
-            dat <- convert_to_numeric(
-              data           = dat,
-              target_columns = "age",
-              lang           = "fr"
-            )
-            expect_s3_class(dat, "data.frame")
-            expect_identical(nrow(dat), 10L)
-            expect_true(all(is.na(dat$age[idx])))
-          })
+  dat <- data[1L:10L, ]
+  idx <- which(is.na(suppressWarnings(as.numeric(dat$age))))
+  dat <- convert_to_numeric(
+    data           = dat,
+    target_columns = "age",
+    lang           = "fr"
+  )
+  expect_s3_class(dat, "data.frame")
+  expect_identical(nrow(dat), 10L)
+  expect_true(all(is.na(dat$age[idx])))
+})
 
 scan_res <- scan_data(data)
 test_that("detect_to_numeric_columns works", {
@@ -55,24 +55,24 @@ test_that("detect_to_numeric_columns works", {
 
 test_that("detect_to_numeric_columns sends a warning when no column is provided
           and scan_data() does not find a target column", {
-            expect_warning(
-              detect_to_numeric_columns(
-                scan_res = scan_res
-              ),
-              regexp = cat("'gender' column has similar number of numeric and
+  expect_warning(
+    detect_to_numeric_columns(
+      scan_res = scan_res
+    ),
+    regexp = cat("'gender' column has similar number of numeric and
                            character values.")
-            )
-          })
+  )
+})
 
 data <- readRDS(system.file("extdata", "test_df1.RDS", package = "cleanepi"))
 test_that("detect_to_numeric_columns sends a warning when no column is provided
           and scan_data() does not find a target column", {
-            expect_error(
-              convert_to_numeric(
-                data           = data,
-                target_columns = NULL
-              ),
-              regexp = cat("target_columns not specified and could not be
+  expect_error(
+    convert_to_numeric(
+      data           = data,
+      target_columns = NULL
+    ),
+    regexp = cat("target_columns not specified and could not be
                            identified from scan_data() function.")
-            )
-          })
+  )
+})

--- a/tests/testthat/test-dev-utils.R
+++ b/tests/testthat/test-dev-utils.R
@@ -1,5 +1,3 @@
 test_that("release_bullets() returns what usethis expects", {
-
   expect_type(release_bullets(), "character")
-
 })

--- a/tests/testthat/test-dictionary_based_cleaning.R
+++ b/tests/testthat/test-dictionary_based_cleaning.R
@@ -1,5 +1,6 @@
 test_dictionary <- readRDS(system.file("extdata", "test_dict.RDS",
-                                       package = "cleanepi"))
+  package = "cleanepi"
+))
 test_that("add_to_dictionary works when adding only one element", {
   test <- add_to_dictionary(
     dictionary = test_dictionary,
@@ -67,7 +68,7 @@ test_dictionary <- add_to_dictionary(
   order      = NULL
 )
 test_that("clean_using_dictionary works", {
-  cleaned_df     <- clean_using_dictionary(
+  cleaned_df <- clean_using_dictionary(
     data       = data,
     dictionary = test_dictionary
   )
@@ -79,7 +80,7 @@ test_that("clean_using_dictionary works", {
 # introduce a new option
 data[["gender"]][2L] <- "femme"
 test_that("clean_using_dictionary works with misspelled values", {
-  cleaned_df     <- clean_using_dictionary(
+  cleaned_df <- clean_using_dictionary(
     data       = data,
     dictionary = test_dictionary
   )
@@ -87,9 +88,13 @@ test_that("clean_using_dictionary works with misspelled values", {
   expect_identical(ncol(data), ncol(cleaned_df))
   expect_false("homme" %in% cleaned_df[["gender"]])
   expect_true("femme" %in% cleaned_df[["gender"]])
-  expect_message(clean_using_dictionary(data       = data,
-                                        dictionary = test_dictionary),
-                 "misspelled values at lines 2 of column 'gender'")
+  expect_message(
+    clean_using_dictionary(
+      data = data,
+      dictionary = test_dictionary
+    ),
+    "misspelled values at lines 2 of column 'gender'"
+  )
 })
 
 test_that("construct_misspelled_report works", {
@@ -109,11 +114,14 @@ test_that("construct_misspelled_report works", {
 # testing internal functions
 test_that("make_readcap_dictionary works as expected", {
   test_data <- readRDS(system.file("extdata", "test_readcap_dictionary.RDS",
-                                   package = "cleanepi"))
-  res <- make_readcap_dictionary(metadata     = test_data,
-                                 field_column = "field_name",
-                                 opt_column = "select_choices_or_calculations",
-                                 field_type   = "field_type")
+    package = "cleanepi"
+  ))
+  res <- make_readcap_dictionary(
+    metadata = test_data,
+    field_column = "field_name",
+    opt_column = "select_choices_or_calculations",
+    field_type = "field_type"
+  )
   expect_s3_class(res, "data.frame")
   expect_identical(ncol(res), 4L)
   expect_identical(nrow(res), 11L)
@@ -122,12 +130,13 @@ test_that("make_readcap_dictionary works as expected", {
 
 test_that("make_readcap_dictionary fails when the column with the options does
           not exist", {
-            expect_error(
-              make_readcap_dictionary(metadata     = test_data,
-                                      field_column = "field_name",
-                                      opt_column = "fake_column_name",
-                                      field_type   = "field_type"),
-              regexp = cat("Unrecognised column name: 'fake_column_name'")
-            )
+  expect_error(
+    make_readcap_dictionary(
+      metadata = test_data,
+      field_column = "field_name",
+      opt_column = "fake_column_name",
+      field_type = "field_type"
+    ),
+    regexp = cat("Unrecognised column name: 'fake_column_name'")
+  )
 })
-

--- a/tests/testthat/test-find_and_remove_duplicates.R
+++ b/tests/testthat/test-find_and_remove_duplicates.R
@@ -1,5 +1,6 @@
 data <- readRDS(system.file("extdata", "test_linelist.RDS",
-                            package = "cleanepi"))
+  package = "cleanepi"
+))
 
 test_that("remove_duplicates works with 'linelist_tags'", {
   no_dups <- remove_duplicates(
@@ -13,13 +14,15 @@ test_that("remove_duplicates works with 'linelist_tags'", {
   report <- attr(no_dups, "report")
   expect_type(report, "list")
   expect_length(report, 3L)
-  expect_named(report, c("duplicated_rows", "duplicates_checked_from",
-                         "removed_duplicates"))
+  expect_named(report, c(
+    "duplicated_rows", "duplicates_checked_from",
+    "removed_duplicates"
+  ))
   expect_true(inherits(report[["duplicated_rows"]], "data.frame"))
   expect_true(inherits(report[["removed_duplicates"]], "data.frame"))
   expect_type(report[["duplicates_checked_from"]], "character")
   expect_true(all(c("row_id", "group_id") %in%
-                    colnames(report[["duplicated_rows"]])))
+    colnames(report[["duplicated_rows"]])))
   expect_false("group_id" %in% colnames(report[["removed_duplicates"]]))
 })
 
@@ -35,13 +38,15 @@ test_that("remove_duplicates works with 'linelist_tags'", {
   report <- attr(no_dups, "report")
   expect_type(report, "list")
   expect_length(report, 3L)
-  expect_named(report, c("duplicated_rows", "duplicates_checked_from",
-                         "removed_duplicates"))
+  expect_named(report, c(
+    "duplicated_rows", "duplicates_checked_from",
+    "removed_duplicates"
+  ))
   expect_true(inherits(report[["duplicated_rows"]], "data.frame"))
   expect_true(inherits(report[["removed_duplicates"]], "data.frame"))
   expect_type(report[["duplicates_checked_from"]], "character")
   expect_true(all(c("row_id", "group_id") %in%
-                    colnames(report[["duplicated_rows"]])))
+    colnames(report[["duplicated_rows"]])))
   expect_false("group_id" %in% colnames(report[["removed_duplicates"]]))
 })
 
@@ -56,7 +61,7 @@ test_that("find_duplicates works with a vector of column names", {
   expect_true(inherits(report[["duplicated_rows"]], "data.frame"))
   expect_type(report[["duplicates_checked_from"]], "character")
   expect_true(all(c("row_id", "group_id") %in%
-                    colnames(report[["duplicated_rows"]])))
+    colnames(report[["duplicated_rows"]])))
 })
 
 test_that("find_duplicates works with 'linelist_tags'", {
@@ -70,7 +75,7 @@ test_that("find_duplicates works with 'linelist_tags'", {
   expect_true(inherits(report[["duplicated_rows"]], "data.frame"))
   expect_type(report[["duplicates_checked_from"]], "character")
   expect_true(all(c("row_id", "group_id") %in%
-                    colnames(report[["duplicated_rows"]])))
+    colnames(report[["duplicated_rows"]])))
 })
 
 test_that("find_duplicates works when target_columns = NULL", {

--- a/tests/testthat/test-print_report.R
+++ b/tests/testthat/test-print_report.R
@@ -1,32 +1,40 @@
 # perform data cleaning
-test_data       <- readRDS(system.file("extdata", "test_df.RDS",
-                                       package = "cleanepi"))
+test_data <- readRDS(system.file("extdata", "test_df.RDS",
+  package = "cleanepi"
+))
 test_dictionary <- readRDS(system.file("extdata", "test_dictionary.RDS",
-                                       package = "cleanepi"))
-cleaned_data      <- test_data %>%
+  package = "cleanepi"
+))
+cleaned_data <- test_data %>%
   standardize_column_names(keep = NULL, rename = NULL) %>%
   replace_missing_values(target_columns = NULL, na_strings = "-99") %>%
   remove_constants(cutoff = 1.0) %>%
   remove_duplicates(target_columns = NULL) %>%
-  standardize_dates(target_columns  = NULL,
-                    error_tolerance = 0.4,
-                    format          = NULL,
-                    timeframe     = as.Date(c("1973-05-29", "2023-05-29"))) %>%
-  check_subject_ids(target_columns = "study_id",
-                    prefix         = "PS",
-                    suffix         = "P2",
-                    range          = c(1L, 100L),
-                    nchar          = 7L) %>%
+  standardize_dates(
+    target_columns = NULL,
+    error_tolerance = 0.4,
+    format = NULL,
+    timeframe = as.Date(c("1973-05-29", "2023-05-29"))
+  ) %>%
+  check_subject_ids(
+    target_columns = "study_id",
+    prefix = "PS",
+    suffix = "P2",
+    range = c(1L, 100L),
+    nchar = 7L
+  ) %>%
   convert_to_numeric(target_columns = "sex") %>%
   clean_using_dictionary(dictionary = test_dictionary)
 
 # scan through the data
-scan_res     <- scan_data(data = test_data)
+scan_res <- scan_data(data = test_data)
 
 # add the data scanning result to the report
-cleaned_data <- add_to_report(x     = cleaned_data,
-                              key   = "scanning_result",
-                              value = scan_res)
+cleaned_data <- add_to_report(
+  x = cleaned_data,
+  key = "scanning_result",
+  value = scan_res
+)
 
 # perform the test
 test_that("print_report works", {

--- a/tests/testthat/test-remove_constants.R
+++ b/tests/testthat/test-remove_constants.R
@@ -16,14 +16,17 @@ test_that("remove_constants works", {
   expect_false(nrow(data) == nrow(dat))
   expect_false(
     all(c("empty_column", "event_name", "country_code", "country_name")) %in%
-      colnames(dat))
+      colnames(dat)
+  )
 
   report <- attr(dat, "report")
   expect_type(report, "list")
   expect_length(report, 3L)
   expect_named(report, c("empty_columns", "empty_rows", "constant_columns"))
   expect_identical(report[["empty_columns"]], "empty_column")
-  expect_identical(report[["constant_columns"]],
-                   c("event_name", "country_code", "country_name"))
+  expect_identical(
+    report[["constant_columns"]],
+    c("event_name", "country_code", "country_name")
+  )
   expect_identical(report[["empty_rows"]], 10L)
 })

--- a/tests/testthat/test-replace_missing_values.R
+++ b/tests/testthat/test-replace_missing_values.R
@@ -1,15 +1,15 @@
 data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
 test_that("replace_missing_values works when both target_columns and na_strings
           are provided", {
-            cleaned_data <- replace_missing_values(
-              data           = data,
-              target_columns = "sex",
-              na_strings     = "-99"
-            )
-            expect_s3_class(cleaned_data, "data.frame")
-            expect_false("-99" %in% cleaned_data[["sex"]])
-            expect_true(anyNA(cleaned_data[["sex"]]))
-            expect_true(all(is.na(cleaned_data[["sex"]][data[["sex"]] == "-99"]))) # nolint: line_length_linter
+  cleaned_data <- replace_missing_values(
+    data           = data,
+    target_columns = "sex",
+    na_strings     = "-99"
+  )
+  expect_s3_class(cleaned_data, "data.frame")
+  expect_false("-99" %in% cleaned_data[["sex"]])
+  expect_true(anyNA(cleaned_data[["sex"]]))
+  expect_true(all(is.na(cleaned_data[["sex"]][data[["sex"]] == "-99"]))) # nolint: line_length_linter
 })
 
 test_that("replace_missing_values works when target_columns is set to NULL", {

--- a/tests/testthat/test-span.R
+++ b/tests/testthat/test-span.R
@@ -1,90 +1,105 @@
 data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi")) %>%
-  replace_missing_values(target_columns = "dateOfBirth",
-                         na_strings     = "-99") %>%
-  standardize_dates(target_columns  = c("dateOfBirth",
-                                        "date_first_pcr_positive_test"),
-                    error_tolerance = 0.0)
+  replace_missing_values(
+    target_columns = "dateOfBirth",
+    na_strings = "-99"
+  ) %>%
+  standardize_dates(
+    target_columns = c(
+      "dateOfBirth",
+      "date_first_pcr_positive_test"
+    ),
+    error_tolerance = 0.0
+  )
 
 test_that("timespan works when the time span is calculated in months and
           remainder is sent in days", {
-            time_span <- timespan(
-              data                = data,
-              target_column       = "dateOfBirth",
-              end_date            = Sys.Date(),
-              span_unit           = "months",
-              span_column_name    = "age_in_months",
-              span_remainder_unit = "days"
-            )
-            expect_s3_class(time_span, "data.frame")
-            expect_identical(ncol(time_span), 10L)
-            expect_identical(names(time_span)[9L:10L], c("age_in_months",
-                                                         "remainder_days"))
-          })
+  time_span <- timespan(
+    data                = data,
+    target_column       = "dateOfBirth",
+    end_date            = Sys.Date(),
+    span_unit           = "months",
+    span_column_name    = "age_in_months",
+    span_remainder_unit = "days"
+  )
+  expect_s3_class(time_span, "data.frame")
+  expect_identical(ncol(time_span), 10L)
+  expect_identical(names(time_span)[9L:10L], c(
+    "age_in_months",
+    "remainder_days"
+  ))
+})
 
 test_that("timespan works when the time span is calculated in months and
           remainder is sent in weeks", {
-            time_span <- timespan(
-              data                = data,
-              target_column       = "dateOfBirth",
-              end_date            = Sys.Date(),
-              span_unit           = "months",
-              span_column_name    = "age_in_months",
-              span_remainder_unit = "weeks"
-            )
-            expect_s3_class(time_span, "data.frame")
-            expect_identical(ncol(time_span), 10L)
-            expect_identical(names(time_span)[9L:10L], c("age_in_months",
-                                                         "remainder_weeks"))
-          })
+  time_span <- timespan(
+    data                = data,
+    target_column       = "dateOfBirth",
+    end_date            = Sys.Date(),
+    span_unit           = "months",
+    span_column_name    = "age_in_months",
+    span_remainder_unit = "weeks"
+  )
+  expect_s3_class(time_span, "data.frame")
+  expect_identical(ncol(time_span), 10L)
+  expect_identical(names(time_span)[9L:10L], c(
+    "age_in_months",
+    "remainder_weeks"
+  ))
+})
 
 test_that("timespan works when the time span is calculated in years and
           remainder is sent in months", {
-            time_span <- timespan(
-              data                = data,
-              target_column       = "dateOfBirth",
-              end_date            = Sys.Date(),
-              span_unit           = "years",
-              span_column_name    = "age_in_years",
-              span_remainder_unit = "months"
-            )
-            expect_s3_class(time_span, "data.frame")
-            expect_identical(ncol(time_span), 10L)
-            expect_identical(names(time_span)[9L:10L],
-                             c("age_in_years", "remainder_months"))
-          })
+  time_span <- timespan(
+    data                = data,
+    target_column       = "dateOfBirth",
+    end_date            = Sys.Date(),
+    span_unit           = "years",
+    span_column_name    = "age_in_years",
+    span_remainder_unit = "months"
+  )
+  expect_s3_class(time_span, "data.frame")
+  expect_identical(ncol(time_span), 10L)
+  expect_identical(
+    names(time_span)[9L:10L],
+    c("age_in_years", "remainder_months")
+  )
+})
 
 test_that("timespan works when the time span is calculated in years and
           remainder is sent in weeks", {
-            time_span <- timespan(
-              data                = data,
-              target_column       = "dateOfBirth",
-              end_date            = Sys.Date(),
-              span_unit           = "years",
-              span_column_name    = "age_in_years",
-              span_remainder_unit = "weeks"
-            )
-            expect_s3_class(time_span, "data.frame")
-            expect_identical(ncol(time_span), 10L)
-            expect_identical(names(time_span)[9L:10L],
-                             c("age_in_years", "remainder_weeks"))
-
-          })
+  time_span <- timespan(
+    data                = data,
+    target_column       = "dateOfBirth",
+    end_date            = Sys.Date(),
+    span_unit           = "years",
+    span_column_name    = "age_in_years",
+    span_remainder_unit = "weeks"
+  )
+  expect_s3_class(time_span, "data.frame")
+  expect_identical(ncol(time_span), 10L)
+  expect_identical(
+    names(time_span)[9L:10L],
+    c("age_in_years", "remainder_weeks")
+  )
+})
 
 test_that("timespan works when the time span is calculated in years and
           remainder is sent in days", {
-            time_span <- timespan(
-              data                = data,
-              target_column       = "dateOfBirth",
-              end_date            = Sys.Date(),
-              span_unit           = "years",
-              span_column_name    = "age_in_years",
-              span_remainder_unit = "days"
-            )
-            expect_s3_class(time_span, "data.frame")
-            expect_identical(ncol(time_span), 10L)
-            expect_identical(names(time_span)[9L:10L],
-                             c("age_in_years", "remainder_days"))
-          })
+  time_span <- timespan(
+    data                = data,
+    target_column       = "dateOfBirth",
+    end_date            = Sys.Date(),
+    span_unit           = "years",
+    span_column_name    = "age_in_years",
+    span_remainder_unit = "days"
+  )
+  expect_s3_class(time_span, "data.frame")
+  expect_identical(ncol(time_span), 10L)
+  expect_identical(
+    names(time_span)[9L:10L],
+    c("age_in_years", "remainder_days")
+  )
+})
 
 test_that("timespan works when the time span is calculated in days", {
   time_span <- timespan(
@@ -157,15 +172,15 @@ test_that("timespan works when the time span is calculated between 2 columns", {
 
 test_that("timespan works when the time span is calculated between a column of
           of the data frame and a vector of dates", {
-            end_date <- data[["date_first_pcr_positive_test"]]
-            time_span <- timespan(
-              data                = data,
-              target_column       = "dateOfBirth",
-              end_date            = end_date,
-              span_unit           = "years",
-              span_column_name    = "elapsed_time",
-              span_remainder_unit = NULL
-            )
+  end_date <- data[["date_first_pcr_positive_test"]]
+  time_span <- timespan(
+    data                = data,
+    target_column       = "dateOfBirth",
+    end_date            = end_date,
+    span_unit           = "years",
+    span_column_name    = "elapsed_time",
+    span_remainder_unit = NULL
+  )
   expect_s3_class(time_span, "data.frame")
   expect_identical(ncol(time_span), 9L)
   expect_identical(names(time_span)[9L], "elapsed_time")

--- a/tests/testthat/test-standardize_date.R
+++ b/tests/testthat/test-standardize_date.R
@@ -2,76 +2,88 @@ data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi")) %>%
   replace_missing_values(na_strings = "-99")
 test_that("standardize_dates works with a data frame", {
   dat <- standardize_dates(
-    data            = data,
-    target_columns  = "date_first_pcr_positive_test",
-    format          = NULL,
-    timeframe       = as.Date(c("1973-05-29", "2023-05-29")),
+    data = data,
+    target_columns = "date_first_pcr_positive_test",
+    format = NULL,
+    timeframe = as.Date(c("1973-05-29", "2023-05-29")),
     error_tolerance = 0.4,
-    orders          = list(world_named_months = c("Ybd", "dby"),
-                           world_digit_months = c("dmy", "Ymd"),
-                           US_formats         = c("Omdy", "YOmd")),
-    modern_excel    = TRUE
+    orders = list(
+      world_named_months = c("Ybd", "dby"),
+      world_digit_months = c("dmy", "Ymd"),
+      US_formats = c("Omdy", "YOmd")
+    ),
+    modern_excel = TRUE
   )
   expect_s3_class(dat, "data.frame")
   expect_true(inherits(dat[["date_first_pcr_positive_test"]], "Date"))
 
   dat <- standardize_dates(
-    data            = data,
-    target_columns  = c("date_first_pcr_positive_test", "date.of.admission"),
-    format          = NULL,
-    timeframe       = NULL,
+    data = data,
+    target_columns = c("date_first_pcr_positive_test", "date.of.admission"),
+    format = NULL,
+    timeframe = NULL,
     error_tolerance = 0.4,
-    orders          = list(world_named_months = c("Ybd", "dby"),
-                           world_digit_months = c("dmy", "Ymd"),
-                           US_formats         = c("Omdy", "YOmd")),
-    modern_excel    = TRUE
+    orders = list(
+      world_named_months = c("Ybd", "dby"),
+      world_digit_months = c("dmy", "Ymd"),
+      US_formats = c("Omdy", "YOmd")
+    ),
+    modern_excel = TRUE
   )
   expect_s3_class(dat, "data.frame")
   expect_true(inherits(dat[["date_first_pcr_positive_test"]], "Date"))
   expect_true(inherits(dat[["date.of.admission"]], "Date"))
 
   dat <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi")) %>%
-    replace_missing_values(target_columns = "dateOfBirth",
-                           na_strings = "-99") %>%
+    replace_missing_values(
+      target_columns = "dateOfBirth",
+      na_strings = "-99"
+    ) %>%
     standardize_dates(
-    target_columns  = NULL,
-    format          = NULL,
-    timeframe       = NULL,
-    error_tolerance = 0.4,
-    orders          = list(world_named_months = c("Ybd", "dby"),
-                           world_digit_months = c("dmy", "Ymd"),
-                           US_formats         = c("Omdy", "YOmd")),
-    modern_excel    = TRUE
-  )
+      target_columns = NULL,
+      format = NULL,
+      timeframe = NULL,
+      error_tolerance = 0.4,
+      orders = list(
+        world_named_months = c("Ybd", "dby"),
+        world_digit_months = c("dmy", "Ymd"),
+        US_formats = c("Omdy", "YOmd")
+      ),
+      modern_excel = TRUE
+    )
   expect_s3_class(dat, "data.frame")
   expect_true(inherits(dat[["date_first_pcr_positive_test"]], "Date"))
   expect_true(inherits(dat[["date.of.admission"]], "Date"))
   expect_true(inherits(dat[["dateOfBirth"]], "Date"))
 
   dat <- standardize_dates(
-    data            = data,
-    target_columns  = "date.of.admission",
-    format          = "%d/%m/%Y",
-    timeframe       = NULL,
+    data = data,
+    target_columns = "date.of.admission",
+    format = "%d/%m/%Y",
+    timeframe = NULL,
     error_tolerance = 0.4,
-    orders          = list(world_named_months = c("Ybd", "dby"),
-                           world_digit_months = c("dmy", "Ymd"),
-                           US_formats         = c("Omdy", "YOmd")),
-    modern_excel    = TRUE
+    orders = list(
+      world_named_months = c("Ybd", "dby"),
+      world_digit_months = c("dmy", "Ymd"),
+      US_formats = c("Omdy", "YOmd")
+    ),
+    modern_excel = TRUE
   )
   expect_s3_class(dat, "data.frame")
   expect_true(inherits(dat[["date.of.admission"]], "Date"))
 
   dat <- standardize_dates(
-    data            = data,
-    target_columns  = "date.of.admission",
-    format          = "%d/%m/%Y",
-    timeframe       = c(as.Date("2021-01-01"), as.Date("2021-03-01")),
+    data = data,
+    target_columns = "date.of.admission",
+    format = "%d/%m/%Y",
+    timeframe = c(as.Date("2021-01-01"), as.Date("2021-03-01")),
     error_tolerance = 0.4,
-    orders          = list(world_named_months = c("Ybd", "dby"),
-                           world_digit_months = c("dmy", "Ymd"),
-                           US_formats         = c("Omdy", "YOmd")),
-    modern_excel    = TRUE
+    orders = list(
+      world_named_months = c("Ybd", "dby"),
+      world_digit_months = c("dmy", "Ymd"),
+      US_formats = c("Omdy", "YOmd")
+    ),
+    modern_excel = TRUE
   )
   expect_s3_class(dat, "data.frame")
   expect_true(inherits(dat[["date.of.admission"]], "Date"))
@@ -80,26 +92,30 @@ test_that("standardize_dates works with a data frame", {
 
 test_that("standardize_dates works when the values are already in ISO format", {
   tmp_data <- standardize_dates(
-    data            = data,
-    target_columns  = "date.of.admission",
-    format          = NULL,
-    timeframe       = NULL,
+    data = data,
+    target_columns = "date.of.admission",
+    format = NULL,
+    timeframe = NULL,
     error_tolerance = 0.4,
-    orders          = list(world_named_months = c("Ybd", "dby"),
-                           world_digit_months = c("dmy", "Ymd"),
-                           US_formats         = c("Omdy", "YOmd")),
-    modern_excel    = TRUE
+    orders = list(
+      world_named_months = c("Ybd", "dby"),
+      world_digit_months = c("dmy", "Ymd"),
+      US_formats = c("Omdy", "YOmd")
+    ),
+    modern_excel = TRUE
   )
   dat <- standardize_dates(
-    data            = tmp_data,
-    target_columns  = "date.of.admission",
-    format          = NULL,
-    timeframe       = NULL,
+    data = tmp_data,
+    target_columns = "date.of.admission",
+    format = NULL,
+    timeframe = NULL,
     error_tolerance = 0.4,
-    orders          = list(world_named_months = c("Ybd", "dby"),
-                           world_digit_months = c("dmy", "Ymd"),
-                           US_formats         = c("Omdy", "YOmd")),
-    modern_excel    = TRUE
+    orders = list(
+      world_named_months = c("Ybd", "dby"),
+      world_digit_months = c("dmy", "Ymd"),
+      US_formats = c("Omdy", "YOmd")
+    ),
+    modern_excel = TRUE
   )
   expect_s3_class(dat, "data.frame")
   expect_true(inherits(dat[["date.of.admission"]], "Date"))
@@ -108,35 +124,42 @@ test_that("standardize_dates works when the values are already in ISO format", {
 test_that("standardize_dates works when the input column is a factor", {
   data[["date.of.admission"]] <- as.factor(data[["date.of.admission"]])
   dat <- standardize_dates(
-    data            = data,
-    target_columns  = "date.of.admission",
-    format          = NULL,
-    timeframe       = NULL,
+    data = data,
+    target_columns = "date.of.admission",
+    format = NULL,
+    timeframe = NULL,
     error_tolerance = 0.4,
-    orders          = list(world_named_months = c("Ybd", "dby"),
-                           world_digit_months = c("dmy", "Ymd"),
-                           US_formats         = c("Omdy", "YOmd")),
-    modern_excel    = TRUE
+    orders = list(
+      world_named_months = c("Ybd", "dby"),
+      world_digit_months = c("dmy", "Ymd"),
+      US_formats = c("Omdy", "YOmd")
+    ),
+    modern_excel = TRUE
   )
   expect_s3_class(dat, "data.frame")
   expect_true(inherits(dat[["date.of.admission"]], "Date"))
 })
 
 data <- readRDS(system.file("extdata", "test_linelist.RDS",
-                            package = "cleanepi")) %>%
-  linelist::make_linelist(date_onset     = "dt_onset",
-                          date_reporting = "dt_report")
+  package = "cleanepi"
+)) %>%
+  linelist::make_linelist(
+    date_onset = "dt_onset",
+    date_reporting = "dt_report"
+  )
 test_that("standardize_dates works with a linelist", {
   dat <- standardize_dates(
-    data            = data,
-    target_columns  = "linelist_tags",
-    format          = NULL,
-    timeframe       = NULL,
+    data = data,
+    target_columns = "linelist_tags",
+    format = NULL,
+    timeframe = NULL,
     error_tolerance = 0.4,
-    orders          = list(world_named_months = c("Ybd", "dby"),
-                           world_digit_months = c("dmy", "Ymd"),
-                           US_formats         = c("Omdy", "YOmd")),
-    modern_excel    = TRUE
+    orders = list(
+      world_named_months = c("Ybd", "dby"),
+      world_digit_months = c("dmy", "Ymd"),
+      US_formats = c("Omdy", "YOmd")
+    ),
+    modern_excel = TRUE
   )
   expect_s3_class(dat, "data.frame")
   expect_true(inherits(dat, "linelist"))
@@ -148,31 +171,37 @@ data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
 test_that("standardize_dates fails as expected", {
   expect_error(
     standardize_dates(
-      data            = data,
-      target_columns  = c("date_first_pcr_positive_test", "fake_column_name"),
-      format          = NULL,
-      timeframe       = NULL,
+      data = data,
+      target_columns = c("date_first_pcr_positive_test", "fake_column_name"),
+      format = NULL,
+      timeframe = NULL,
       error_tolerance = 0.4,
-      orders          = list(world_named_months = c("Ybd", "dby"),
-                             world_digit_months = c("dmy", "Ymd"),
-                             US_formats         = c("Omdy", "YOmd")),
-      modern_excel    = TRUE
+      orders = list(
+        world_named_months = c("Ybd", "dby"),
+        world_digit_months = c("dmy", "Ymd"),
+        US_formats = c("Omdy", "YOmd")
+      ),
+      modern_excel = TRUE
     ),
     regexp = cat("Can't find columns: fake_column_name")
   )
 
   expect_error(
     standardize_dates(
-      data            = data,
-      target_columns  = c("date_first_pcr_positive_test", "date.of.admission",
-                          "dateOfBirth"),
-      format          = c("%d/%m/%Y", "%d/%m/%Y"),
-      timeframe       = NULL,
+      data = data,
+      target_columns = c(
+        "date_first_pcr_positive_test", "date.of.admission",
+        "dateOfBirth"
+      ),
+      format = c("%d/%m/%Y", "%d/%m/%Y"),
+      timeframe = NULL,
       error_tolerance = 0.4,
-      orders          = list(world_named_months = c("Ybd", "dby"),
-                             world_digit_months = c("dmy", "Ymd"),
-                             US_formats         = c("Omdy", "YOmd")),
-      modern_excel    = TRUE
+      orders = list(
+        world_named_months = c("Ybd", "dby"),
+        world_digit_months = c("dmy", "Ymd"),
+        US_formats = c("Omdy", "YOmd")
+      ),
+      modern_excel = TRUE
     ),
     regexp = cat("Can't find columns: fake_column_name")
   )
@@ -180,23 +209,31 @@ test_that("standardize_dates fails as expected", {
 
 test_that("date_guess works as expected", {
   data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
-  res <- date_guess(x            = data[["date.of.admission"]],
-                    quiet        = TRUE,
-                    modern_excel = TRUE,
-                    orders       = "dmY")
-  expect_identical(res[["res"]],
-                   as.Date(c("2020-12-01", "2021-01-28", "2021-02-15",
-                             "2021-02-11", "2021-02-17", "2021-02-17",
-                             "2021-02-28", "2021-02-22", "2021-03-02",
-                             "2021-03-05")))
+  res <- date_guess(
+    x = data[["date.of.admission"]],
+    quiet = TRUE,
+    modern_excel = TRUE,
+    orders = "dmY"
+  )
+  expect_identical(
+    res[["res"]],
+    as.Date(c(
+      "2020-12-01", "2021-01-28", "2021-02-15",
+      "2021-02-11", "2021-02-17", "2021-02-17",
+      "2021-02-28", "2021-02-22", "2021-03-02",
+      "2021-03-05"
+    ))
+  )
 })
 
 test_that("date_guess fails as expected", {
   expect_error(
-    date_guess(x            = data[["date.of.admission"]],
-               quiet        = TRUE,
-               modern_excel = TRUE,
-               orders       = NULL),
+    date_guess(
+      x = data[["date.of.admission"]],
+      quiet = TRUE,
+      modern_excel = TRUE,
+      orders = NULL
+    ),
     regexp = cat("orders must be a list of character vectors")
   )
 })

--- a/tests/testthat/test-standardize_subject_ids.R
+++ b/tests/testthat/test-standardize_subject_ids.R
@@ -2,19 +2,19 @@ data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
 
 test_that("check_subject_ids works as expected when all parameters are
           provided", {
-            dat <- check_subject_ids(
-              data           = data,
-              target_columns = "study_id",
-              prefix         = "PS",
-              suffix         = "P2",
-              range          = c(1L, 100L),
-              nchar          = 7L
-            )
-            expect_s3_class(dat, "data.frame")
-            expect_false(identical(data, dat))
-            expect_true(nrow(data) == nrow(dat))
-            expect_true(all(c("PS004P2-1", "P0005P2", "PB500P2") %in%
-                              dat[["study_id"]]))
+  dat <- check_subject_ids(
+    data           = data,
+    target_columns = "study_id",
+    prefix         = "PS",
+    suffix         = "P2",
+    range          = c(1L, 100L),
+    nchar          = 7L
+  )
+  expect_s3_class(dat, "data.frame")
+  expect_false(identical(data, dat))
+  expect_true(nrow(data) == nrow(dat))
+  expect_true(all(c("PS004P2-1", "P0005P2", "PB500P2") %in%
+    dat[["study_id"]]))
 })
 
 test_that("check_subject_ids fails as expected", {
@@ -45,13 +45,14 @@ test_that("check_subject_ids fails as expected", {
 
   expect_error(
     check_subject_ids(
-      data           = readRDS(system.file("extdata", "test_df.RDS",
-                                           package = "cleanepi")),
+      data = readRDS(system.file("extdata", "test_df.RDS",
+        package = "cleanepi"
+      )),
       target_columns = NA,
-      prefix         = "PS",
-      suffix         = "P2",
-      range          = c(1L, 100L),
-      nchar          = NULL
+      prefix = "PS",
+      suffix = "P2",
+      range = c(1L, 100L),
+      nchar = NULL
     ),
     regexp = cat("Assertion on',id_column_name,'failed: Missing value not
                  allowed for 'id_column_name'.")
@@ -59,13 +60,14 @@ test_that("check_subject_ids fails as expected", {
 
   expect_error(
     check_subject_ids(
-      data           = readRDS(system.file("extdata", "test_df.RDS",
-                                           package = "cleanepi")),
+      data = readRDS(system.file("extdata", "test_df.RDS",
+        package = "cleanepi"
+      )),
       target_columns = c("study_id", "event_name"),
-      prefix         = "PS",
-      suffix         = "P2",
-      range          = c(1L, 100L),
-      nchar          = NULL
+      prefix = "PS",
+      suffix = "P2",
+      range = c(1L, 100L),
+      nchar = NULL
     ),
     regexp = cat("Assertion on',id_column_name,'failed: Must be a character of
                  length 1.")
@@ -73,13 +75,14 @@ test_that("check_subject_ids fails as expected", {
 
   expect_error(
     check_subject_ids(
-      data           = readRDS(system.file("extdata", "test_df.RDS",
-                                           package = "cleanepi")),
+      data = readRDS(system.file("extdata", "test_df.RDS",
+        package = "cleanepi"
+      )),
       target_columns = "study_id",
-      prefix         = "PS",
-      suffix         = "P2",
-      range          = c(1L, 100L),
-      nchar          = NA
+      prefix = "PS",
+      suffix = "P2",
+      range = c(1L, 100L),
+      nchar = NA
     ),
     regexp = cat("Assertion on',nchar,'failed: template sample IDs format
                  must be provided.")
@@ -90,12 +93,14 @@ test_that("check_subject_ids sends a message when duplicated IDs are found", {
   data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
   data[["study_id"]][[10L]] <- data[["study_id"]][[1L]]
   expect_message(
-    check_subject_ids(data           = data,
-                      target_columns = "study_id",
-                      prefix         = "PS",
-                      suffix         = "P2",
-                      range          = c(1L, 100L),
-                      nchar          = 7L),
+    check_subject_ids(
+      data = data,
+      target_columns = "study_id",
+      prefix = "PS",
+      suffix = "P2",
+      range = c(1L, 100L),
+      nchar = 7L
+    ),
     "Found 2 duplicated rows. Please consult the report for more details."
   )
 })
@@ -103,8 +108,10 @@ test_that("check_subject_ids sends a message when duplicated IDs are found", {
 test_that("check_subject_ids when the id column is numeric", {
   data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
   data[["case_id"]] <- seq_len(nrow(data))
-  dat <- check_subject_ids(data           = data,
-                           target_columns = "case_id")
+  dat <- check_subject_ids(
+    data = data,
+    target_columns = "case_id"
+  )
   expect_s3_class(dat, "data.frame")
   expect_false(identical(data, dat))
   expect_true(nrow(data) == nrow(dat))
@@ -112,33 +119,39 @@ test_that("check_subject_ids when the id column is numeric", {
 
 data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
 test_that("check_subject_ids works when relying on the nchar argument", {
-  dat <- check_subject_ids(data           = data,
-                           target_columns = "study_id",
-                           prefix         = NULL,
-                           suffix         = NULL,
-                           range          = NULL,
-                           nchar          = 7L)
+  dat <- check_subject_ids(
+    data = data,
+    target_columns = "study_id",
+    prefix = NULL,
+    suffix = NULL,
+    range = NULL,
+    nchar = 7L
+  )
   expect_s3_class(dat, "data.frame")
   expect_true(nrow(data) == nrow(dat))
   expect_true("PS004P2-1" %in% dat[["study_id"]])
 
-  dat <- check_subject_ids(data           = data,
-                           target_columns = "study_id",
-                           prefix         = NULL,
-                           suffix         = NULL,
-                           range          = c(1L, 100L),
-                           nchar          = 7L)
+  dat <- check_subject_ids(
+    data = data,
+    target_columns = "study_id",
+    prefix = NULL,
+    suffix = NULL,
+    range = c(1L, 100L),
+    nchar = 7L
+  )
   expect_s3_class(dat, "data.frame")
   expect_true(nrow(data) == nrow(dat))
   expect_true("PS004P2-1" %in% dat[["study_id"]])
   expect_true("PB500P2" %in% dat[["study_id"]])
 
-  dat <- check_subject_ids(data           = data,
-                           target_columns = "study_id",
-                           prefix         = "PS",
-                           suffix         = NULL,
-                           range          = c(1L, 100L),
-                           nchar          = 7L)
+  dat <- check_subject_ids(
+    data = data,
+    target_columns = "study_id",
+    prefix = "PS",
+    suffix = NULL,
+    range = c(1L, 100L),
+    nchar = 7L
+  )
   expect_s3_class(dat, "data.frame")
   expect_true(nrow(data) == nrow(dat))
   expect_true("PS004P2-1" %in% dat[["study_id"]])
@@ -180,7 +193,7 @@ test_that("correct_subject_ids works as expected", {
   expect_true(all(c("PS004P2", "PB005P2", "PB050P2") %in% dat[["study_id"]]))
   expect_true("incorrect_subject_id" %in% names(report))
   expect_true(all(c("PS004P2-1", "P0005P2", "PB500P2") %in%
-                    report[["incorrect_subject_id"]][["ids"]]))
+    report[["incorrect_subject_id"]][["ids"]]))
   expect_identical(ncol(report[["incorrect_subject_id"]]), 2L)
   expect_identical(nrow(report[["incorrect_subject_id"]]), 3L)
 })
@@ -217,12 +230,14 @@ test_that("check_subject_ids fails as expected", {
   data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
   data[["study_id"]][[7]] <- NA_character_
   expect_warning(
-    check_subject_ids(data           = data,
-                      target_columns = "study_id",
-                      prefix         = "PS",
-                      suffix         = "P2",
-                      range          = c(1L, 100L),
-                      nchar          = 7L),
+    check_subject_ids(
+      data = data,
+      target_columns = "study_id",
+      prefix = "PS",
+      suffix = "P2",
+      range = c(1L, 100L),
+      nchar = 7L
+    ),
     regexp = cat("Missing values found on ID column in lines: 7")
   )
 })
@@ -230,12 +245,14 @@ test_that("check_subject_ids fails as expected", {
 # test multiple prefix and suffix
 data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
 test_that("check_subject_ids works when relying on the nchar argument", {
-  dat <- check_subject_ids(data           = data,
-                           target_columns = "study_id",
-                           prefix         = c("PS", "PB"),
-                           suffix         = c("P2", "P2-1"),
-                           range          = c(1L, 100L),
-                           nchar          = 7L)
+  dat <- check_subject_ids(
+    data = data,
+    target_columns = "study_id",
+    prefix = c("PS", "PB"),
+    suffix = c("P2", "P2-1"),
+    range = c(1L, 100L),
+    nchar = 7L
+  )
   expect_s3_class(dat, "data.frame")
   expect_true(nrow(data) == nrow(dat))
   report <- attr(dat, "report")
@@ -243,6 +260,8 @@ test_that("check_subject_ids works when relying on the nchar argument", {
   expect_named(report, "incorrect_subject_id")
   expect_s3_class(report[["incorrect_subject_id"]], "data.frame")
   expect_identical(report[["incorrect_subject_id"]][["idx"]], c(3L, 5L, 7L))
-  expect_identical(report[["incorrect_subject_id"]][["ids"]],
-                   c("PS004P2-1", "P0005P2", "PB500P2"))
+  expect_identical(
+    report[["incorrect_subject_id"]][["ids"]],
+    c("PS004P2-1", "P0005P2", "PB500P2")
+  )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,53 +1,59 @@
 test_that("get_target_column_names works with
           target_columns = 'linelist_tags'", {
-            target_columns <- get_target_column_names(
-              data           = readRDS(system.file("extdata",
-                                                   "test_linelist.RDS",
-                                                   package = "cleanepi")),
-              target_columns = "linelist_tags",
-              cols           = NULL
-            )
-            expect_type(target_columns, "character")
-            expect_length(target_columns, 4L)
-            expect_identical(target_columns, c("dt_onset", "dt_report", "sex",
-                                               "outcome"))
-          })
+  target_columns <- get_target_column_names(
+    data = readRDS(system.file("extdata",
+      "test_linelist.RDS",
+      package = "cleanepi"
+    )),
+    target_columns = "linelist_tags",
+    cols = NULL
+  )
+  expect_type(target_columns, "character")
+  expect_length(target_columns, 4L)
+  expect_identical(target_columns, c(
+    "dt_onset", "dt_report", "sex",
+    "outcome"
+  ))
+})
 
 test_that("get_target_column_names works with
           target_columns as a vector of column names", {
-            target_columns <- get_target_column_names(
-              data           = readRDS(system.file("extdata",
-                                                   "test_df.RDS",
-                                                   package = "cleanepi")),
-              target_columns = c("dateOfBirth", "sex"),
-              cols           = NULL
-            )
-            expect_type(target_columns, "character")
-            expect_length(target_columns, 2L)
-            expect_identical(target_columns, c("dateOfBirth", "sex"))
-          })
+  target_columns <- get_target_column_names(
+    data = readRDS(system.file("extdata",
+      "test_df.RDS",
+      package = "cleanepi"
+    )),
+    target_columns = c("dateOfBirth", "sex"),
+    cols = NULL
+  )
+  expect_type(target_columns, "character")
+  expect_length(target_columns, 2L)
+  expect_identical(target_columns, c("dateOfBirth", "sex"))
+})
 
 test_that("get_target_column_names works with
           target_columns as a vector of numeric values", {
-            target_columns <- get_target_column_names(
-              data           = readRDS(system.file("extdata",
-                                                   "test_df.RDS",
-                                                   package = "cleanepi")),
-              target_columns = c(6L, 8L),
-              cols           = NULL
-            )
-            expect_type(target_columns, "character")
-            expect_length(target_columns, 2L)
-            expect_identical(target_columns, c("dateOfBirth", "sex"))
-          })
+  target_columns <- get_target_column_names(
+    data = readRDS(system.file("extdata",
+      "test_df.RDS",
+      package = "cleanepi"
+    )),
+    target_columns = c(6L, 8L),
+    cols = NULL
+  )
+  expect_type(target_columns, "character")
+  expect_length(target_columns, 2L)
+  expect_identical(target_columns, c("dateOfBirth", "sex"))
+})
 
 test_that("get_target_column_names works with target_columns and cols", {
   target_columns <- get_target_column_names(
-    data           = readRDS(system.file("extdata",
-                                         "test_df.RDS",
-                                         package = "cleanepi")),
+    data = readRDS(system.file("extdata",
+      "test_df.RDS",
+      package = "cleanepi"
+    )),
     target_columns = c("dateOfBirth", "sex", "country_name"),
-    cols           = "country_name"
+    cols = "country_name"
   )
   expect_type(target_columns, "character")
   expect_length(target_columns, 2L)
@@ -57,11 +63,12 @@ test_that("get_target_column_names works with target_columns and cols", {
 test_that("get_target_column_names fails as expected", {
   expect_error(
     get_target_column_names(
-      data           = readRDS(system.file("extdata",
-                                           "test_df.RDS",
-                                           package = "cleanepi")),
+      data = readRDS(system.file("extdata",
+        "test_df.RDS",
+        package = "cleanepi"
+      )),
       target_columns = "country_name",
-      cols           = "country_name"
+      cols = "country_name"
     ),
     regexp = cat("Assertion on',target_columns,'failed: all specified target
                  columns will be ignored because they are either empty or
@@ -72,18 +79,19 @@ test_that("get_target_column_names fails as expected", {
 test_that("get_target_column_names fails as expected", {
   expect_error(
     get_target_column_names(
-      data           = readRDS(system.file("extdata",
-                                           "test_df.RDS",
-                                           package = "cleanepi")),
+      data = readRDS(system.file("extdata",
+        "test_df.RDS",
+        package = "cleanepi"
+      )),
       target_columns = "linelist_tags",
-      cols           = NULL
+      cols = NULL
     ),
     regexp = cat("Assertion on',keep,'failed: usage of 'linelist_tags'
                  is only reserved for 'linelist' type of data.")
   )
 })
 
-data     <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
+data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
 scan_res <- scan_data(data)
 
 # Perform data cleaning
@@ -92,27 +100,35 @@ cleaned_data <- data %>%
   convert_to_numeric(target_columns = "sex", lang = "en")
 
 test_that("add_to_report works as expected", {
-  cleaned_data <- add_to_report(x     = cleaned_data,
-                                key   = "scanning_result",
-                                value = scan_res)
+  cleaned_data <- add_to_report(
+    x = cleaned_data,
+    key = "scanning_result",
+    value = scan_res
+  )
   report <- attr(cleaned_data, "report")
   expect_type(report, "list")
   expect_length(report, 3L)
-  expect_named(report, c("missing_values_replaced_at", "converted_into_numeric",
-                         "scanning_result"))
+  expect_named(report, c(
+    "missing_values_replaced_at", "converted_into_numeric",
+    "scanning_result"
+  ))
   expect_identical(report[["missing_values_replaced_at"]], "sex")
   expect_identical(report[["converted_into_numeric"]], "sex")
 
-  data <- add_to_report(x     = data,
-                        key   = "scanning_result",
-                        value = scan_res)
+  data <- add_to_report(
+    x = data,
+    key = "scanning_result",
+    value = scan_res
+  )
   report <- attr(data, "report")
   expect_type(report, "list")
   expect_length(report, 1L)
   expect_named(report, "scanning_result")
-  expect_named(report[["scanning_result"]], c("Field_names", "missing",
-                                              "numeric", "date", "character",
-                                              "logical"))
+  expect_named(report[["scanning_result"]], c(
+    "Field_names", "missing",
+    "numeric", "date", "character",
+    "logical"
+  ))
   expect_identical(nrow(report[["scanning_result"]]), ncol(data))
 })
 

--- a/vignettes/cleanepi.Rmd
+++ b/vignettes/cleanepi.Rmd
@@ -11,8 +11,8 @@ vignette: >
 
 ```{r, include = FALSE} 
 knitr::opts_chunk[["set"]](collapse = TRUE, comment = "#>", eval = FALSE,
-                           fig.width = 7L, fig.height = 7L,
-                           fig.align = "center")
+  fig.width = 7L, fig.height = 7L,
+  fig.align = "center")
 row_id <- group_id <- NULL
 ```
 
@@ -51,17 +51,20 @@ The main function in **{cleanepi}** is `clean_data()` that can perform the follo
 ```{r eval=TRUE, comment=""}
 # IMPORTING THE TEST DATASET
 test_data <- readRDS(system.file("extdata", "test_df.RDS",
-                                 package = "cleanepi"))
+  package = "cleanepi"
+))
 ```
 
 ```{r eval=TRUE, echo=FALSE}
 test_data %>%
   kableExtra::kbl() %>%
   kableExtra::kable_paper("striped", font_size = 14, full_width = TRUE) %>%
-  kableExtra::scroll_box(height = "200px", width = "100%",
-                         box_css = "border: 1px solid #ddd; padding: 5px; ",
-                         extra_css = NULL,
-                         fixed_thead = TRUE)
+  kableExtra::scroll_box(
+    height = "200px", width = "100%",
+    box_css = "border: 1px solid #ddd; padding: 5px; ",
+    extra_css = NULL,
+    fixed_thead = TRUE
+  )
 ```
 
 ```{r eval=TRUE, comment=""}
@@ -73,10 +76,12 @@ scan_result <- scan_data(test_data)
 scan_result %>%
   kableExtra::kbl() %>%
   kableExtra::kable_paper("striped", font_size = 14, full_width = FALSE) %>%
-  kableExtra::scroll_box(height = "200px", width = "100%",
-                         box_css = "border: 1px solid #ddd; padding: 5px; ",
-                         extra_css = NULL,
-                         fixed_thead = TRUE)
+  kableExtra::scroll_box(
+    height = "200px", width = "100%",
+    box_css = "border: 1px solid #ddd; padding: 5px; ",
+    extra_css = NULL,
+    fixed_thead = TRUE
+  )
 ```
 
 In **{cleanepi}**, every cleaning operation is encapsulated within a module, with detailed descriptions provided in the package design vignette. Each module also specifies the parameters required for its main function, outlined in the sections below.
@@ -91,31 +96,38 @@ rm_na <- list(target_columns = NULL, na_strings = "-99")
 standardize_col_names <- list(keep = NULL, rename = NULL)
 
 # PARAMETERS FOR DUBLICATES DETECTION AND REMOVAL
-rm_dup <- list(target_columns   = NULL)
+rm_dup <- list(target_columns = NULL)
 
 # PARAMETERS FOR STANDARDING DATES
-stdn_date <- list(target_columns  = NULL,
-                  error_tolerance = 0.4,
-                  format          = NULL,
-                  timeframe       = as.Date(c("1973-05-29", "2023-05-29")),
-                  orders          = list(world_named_months = c("Ybd", "dby"),
-                                         world_digit_months = c("dmy", "Ymd"),
-                                         US_formats       = c("Omdy", "YOmd")),
-                  modern_excel    = TRUE)
+stdn_date <- list(
+  target_columns = NULL,
+  error_tolerance = 0.4,
+  format = NULL,
+  timeframe = as.Date(c("1973-05-29", "2023-05-29")),
+  orders = list(
+    world_named_months = c("Ybd", "dby"),
+    world_digit_months = c("dmy", "Ymd"),
+    US_formats = c("Omdy", "YOmd")
+  ),
+  modern_excel = TRUE
+)
 
 # PARAMETERS FOR STANDARDING SUBJECT IDs
-stdn_ids <- list(target_columns = "study_id",
-                 prefix         = "PS",
-                 suffix         = "P2",
-                 range          = c(1, 100),
-                 nchar          = 7)
+stdn_ids <- list(
+  target_columns = "study_id",
+  prefix = "PS",
+  suffix = "P2",
+  range = c(1, 100),
+  nchar = 7
+)
 
 # PARAMETERS FOR CONSTANT COLUMNS, EMPTY ROWS AND COLUMNS REMOVAL
 remove_cte <- list(cutoff = 1)
 
 # LAOD THE DATA DICTIONARY
 test_dictionary <- readRDS(system.file("extdata", "test_dictionary.RDS",
-                                       package = "cleanepi"))
+  package = "cleanepi"
+))
 
 # DEFINE THE LIST OF PARAMETERS
 params <- list(
@@ -185,18 +197,22 @@ data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
 data$empty_column <- NA
 
 # remove the constant columns, empty rows and columns
-dat <- remove_constants(data   = data,
-                        cutoff = 1)
+dat <- remove_constants(
+  data = data,
+  cutoff = 1
+)
 ```
 
 ```{r echo=FALSE, eval=TRUE}
 dat %>%
   kableExtra::kbl() %>%
   kableExtra::kable_paper("striped", font_size = 14, full_width = TRUE) %>%
-  kableExtra::scroll_box(height = "200px", width = "100%",
-                         box_css = "border: 1px solid #ddd; padding: 5px; ",
-                         extra_css = NULL,
-                         fixed_thead = TRUE)
+  kableExtra::scroll_box(
+    height = "200px", width = "100%",
+    box_css = "border: 1px solid #ddd; padding: 5px; ",
+    extra_css = NULL,
+    fixed_thead = TRUE
+  )
 ```
 
 The `remove_constants()` function returns a dataset where all constant columns, empty rows and columns are removed.
@@ -253,18 +269,20 @@ print(cleanepi::common_na_strings)
 ```{r eval=TRUE, comment="replace_missing"}
 # REPLACE ALL OCCURENCES OF "-99" WITH NA IN THE "sex" COLUMN
 cleaned_data <- replace_missing_values(
-  data           = readRDS(system.file("extdata", "test_df.RDS",
-                                       package = "cleanepi")),
+  data = readRDS(system.file("extdata", "test_df.RDS",
+    package = "cleanepi"
+  )),
   target_columns = "sex",
-  na_strings     = "-99"
+  na_strings = "-99"
 )
 
 # REPLACE ALL OCCURENCES OF "-99" WITH NA FROM ALL COLUMNS
 cleaned_data <- replace_missing_values(
-  data           = readRDS(system.file("extdata", "test_df.RDS",
-                                       package = "cleanepi")),
+  data = readRDS(system.file("extdata", "test_df.RDS",
+    package = "cleanepi"
+  )),
   target_columns = NULL,
-  na_strings     = "-99"
+  na_strings = "-99"
 )
 ```
 
@@ -272,10 +290,12 @@ cleaned_data <- replace_missing_values(
 cleaned_data %>%
   kableExtra::kbl() %>%
   kableExtra::kable_paper("striped", font_size = 14, full_width = TRUE) %>%
-  kableExtra::scroll_box(height = "200px", width = "100%",
-                         box_css = "border: 1px solid #ddd; padding: 5px; ",
-                         extra_css = NULL,
-                         fixed_thead = TRUE)
+  kableExtra::scroll_box(
+    height = "200px", width = "100%",
+    box_css = "border: 1px solid #ddd; padding: 5px; ",
+    extra_css = NULL,
+    fixed_thead = TRUE
+  )
 ```
 
 
@@ -325,20 +345,23 @@ This function provides users with the flexibility to standardize date columns in
 ```{r eval=TRUE, comment="date_standardisation"}
 # STANDARDIZE VALUES IN THE 'date_first_pcr_positive_test' COLUMN
 test_data <- readRDS(system.file("extdata", "test_df.RDS",
-                                 package = "cleanepi"))
+  package = "cleanepi"
+))
 
 head(test_data$date_first_pcr_positive_test)
 
 res <- standardize_dates(
-  data            = test_data,
-  target_columns  = "date_first_pcr_positive_test",
-  format          = NULL,
-  timeframe       = NULL,
+  data = test_data,
+  target_columns = "date_first_pcr_positive_test",
+  format = NULL,
+  timeframe = NULL,
   error_tolerance = 0.4,
-  orders          = list(world_named_months = c("Ybd", "dby"),
-                         world_digit_months = c("dmy", "Ymd"),
-                         US_formats         = c("Omdy", "YOmd")),
-  modern_excel    = TRUE
+  orders = list(
+    world_named_months = c("Ybd", "dby"),
+    world_digit_months = c("dmy", "Ymd"),
+    US_formats = c("Omdy", "YOmd")
+  ),
+  modern_excel = TRUE
 )
 ```
 
@@ -348,10 +371,12 @@ This function returns the input dataset where the (specified) columns are conver
 res %>%
   kableExtra::kbl() %>%
   kableExtra::kable_paper("striped", font_size = 14, full_width = TRUE) %>%
-  kableExtra::scroll_box(height = "200px", width = "100%",
-                         box_css = "border: 1px solid #ddd; padding: 5px; ",
-                         extra_css = NULL,
-                         fixed_thead = TRUE)
+  kableExtra::scroll_box(
+    height = "200px", width = "100%",
+    box_css = "border: 1px solid #ddd; padding: 5px; ",
+    extra_css = NULL,
+    fixed_thead = TRUE
+  )
 ```
 
 It also adds two or three elements to the report object:
@@ -363,15 +388,17 @@ It also adds two or three elements to the report object:
 ```{r echo=FALSE, eval=TRUE}
 # STANDARDIZE VALUES IN ALL COLUMNS
 res <- standardize_dates(
-  data            = test_data,
-  target_columns  = NULL,
-  format          = NULL,
-  timeframe       = NULL,
+  data = test_data,
+  target_columns = NULL,
+  format = NULL,
+  timeframe = NULL,
   error_tolerance = 0.4,
-  orders          = list(world_named_months = c("Ybd", "dby"),
-                         world_digit_months = c("dmy", "Ymd"),
-                         US_formats         = c("Omdy", "YOmd")),
-  modern_excel    = TRUE
+  orders = list(
+    world_named_months = c("Ybd", "dby"),
+    world_digit_months = c("dmy", "Ymd"),
+    US_formats = c("Omdy", "YOmd")
+  ),
+  modern_excel = TRUE
 )
 
 # GET THE REPORT
@@ -381,10 +408,12 @@ report <- attr(res, "report")
 report$multi_format_dates %>%
   kableExtra::kbl() %>%
   kableExtra::kable_paper("striped", font_size = 14, full_width = TRUE) %>%
-  kableExtra::scroll_box(height = "200px", width = "100%",
-                         box_css = "border: 1px solid #ddd; padding: 5px; ",
-                         extra_css = NULL,
-                         fixed_thead = TRUE)
+  kableExtra::scroll_box(
+    height = "200px", width = "100%",
+    box_css = "border: 1px solid #ddd; padding: 5px; ",
+    extra_css = NULL,
+    fixed_thead = TRUE
+  )
 ```
 
 
@@ -407,13 +436,14 @@ By providing these parameters, the function becomes a versatile tool for data cl
 ```{r eval=TRUE, comment="subject_ids_standardisation"}
 # DETECT AND REMOVE INCORRECT SUBJECT IDs
 res <- check_subject_ids(
-  data           = readRDS(system.file("extdata", "test_df.RDS",
-                                       package = "cleanepi")),
+  data = readRDS(system.file("extdata", "test_df.RDS",
+    package = "cleanepi"
+  )),
   target_columns = "study_id",
-  prefix         = "PS",
-  suffix         = "P2",
-  range          = c(1L, 100L),
-  nchar          = 7L
+  prefix = "PS",
+  suffix = "P2",
+  range = c(1L, 100L),
+  nchar = 7L
 )
 
 # EXTRACT REPORT
@@ -442,7 +472,7 @@ data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi"))
 # GENERATE THE CORRECTION TABLE
 correction_table <- data.frame(
   from = c("P0005P2", "PB500P2", "PS004P2-1"),
-  to   = c("PB005P2", "PB050P2", "PS004P2"),
+  to = c("PB005P2", "PB050P2", "PS004P2"),
   stringsAsFactors = FALSE
 )
 
@@ -467,8 +497,9 @@ By utilizing these arguments, the `check_date_sequence()` function facilitates t
 ```{r eval=TRUE, comment="check_date_order"}
 # DETECT ROWS WITH INCORRECT DATE SEQUENCE
 res <- check_date_sequence(
-  data           = readRDS(system.file("extdata", "test_df.RDS",
-                                       package = "cleanepi")),
+  data = readRDS(system.file("extdata", "test_df.RDS",
+    package = "cleanepi"
+  )),
   target_columns = c("date_first_pcr_positive_test", "date.of.admission")
 )
 
@@ -550,16 +581,19 @@ By leveraging the `find_duplicates()` function with appropriate parameters, user
 ```{r eval=TRUE, comment=""}
 # IMPORT A `linelist` DATA
 data <- readRDS(system.file("extdata", "test_linelist.RDS",
-                            package = "cleanepi"))
+  package = "cleanepi"
+))
 
 # SHOW THE TAGGED VARIABLES
 linelist::tags(data)
 
 # FIND DUPLICATES ACROSS ALL COLUMNS EXCEPT THE SUBJECT IDs COLUMN
-all_columns    <- names(data)
+all_columns <- names(data)
 target_columns <- all_columns[all_columns != "id"]
-dups           <- find_duplicates(data           = data,
-                                  target_columns = target_columns)
+dups <- find_duplicates(
+  data = data,
+  target_columns = target_columns
+)
 
 # FIND DUPLICATES ACROSS TAGGED VARIABLES
 dups <- find_duplicates(
@@ -577,15 +611,17 @@ By including these extra columns, users gain insights into the specific rows ide
 
 ```{r eval=TRUE}
 # VISUALIZE THE DUPLICATES
-report     <- attr(dups, "report")
+report <- attr(dups, "report")
 duplicates <- report$duplicated_rows
 duplicates %>%
   kableExtra::kbl() %>%
   kableExtra::kable_paper("striped", font_size = 14, full_width = FALSE) %>%
-  kableExtra::scroll_box(height = "200px", width = "100%",
-                         box_css = "border: 1px solid #ddd; padding: 5px; ",
-                         extra_css = NULL,
-                         fixed_thead = TRUE)
+  kableExtra::scroll_box(
+    height = "200px", width = "100%",
+    box_css = "border: 1px solid #ddd; padding: 5px; ",
+    extra_css = NULL,
+    fixed_thead = TRUE
+  )
 ```
 
 ## Removing duplicates
@@ -598,8 +634,9 @@ To eliminate duplicated rows from a dataset, the `remove_duplicates()` function 
 ```{r eval=TRUE}
 # REMOVE DUPLICATE ACROSS TAGGED COLUMNS ONLY.
 res <- remove_duplicates(
-  data           = readRDS(system.file("extdata", "test_linelist.RDS",
-                                       package = "cleanepi")),
+  data = readRDS(system.file("extdata", "test_linelist.RDS",
+    package = "cleanepi"
+  )),
   target_columns = "linelist_tags"
 )
 ```
@@ -628,13 +665,14 @@ The output from `find_duplicates()` function can also be passed to `remove_dupli
 ```{r eval=TRUE, comment="find_and_remove_dups"}
 # DETECT DUPLICATES FROM TAGGED COLUMNS
 dups <- find_duplicates(
-  data           = readRDS(system.file("extdata", "test_linelist.RDS",
-                                       package = "cleanepi")),
+  data = readRDS(system.file("extdata", "test_linelist.RDS",
+    package = "cleanepi"
+  )),
   target_columns = "linelist_tags"
 )
 
 # EXTRACT THE DUPLICATES
-report     <- attr(dups, "report")
+report <- attr(dups, "report")
 duplicates <- report$duplicated_rows
 
 # REMOVE FIRST OCCURRENCE OF DUPLICATED ROWS
@@ -666,14 +704,16 @@ In the example below, we add `-99` to our test data dictionary, `test_dictionary
 ```{r eval=TRUE}
 # READING IN THE DATA
 data <- readRDS(system.file("extdata", "test_df.RDS",
-                            package = "cleanepi"))
+  package = "cleanepi"
+))
 
 # ADD THE EXTRA OPTION TO THE DICTIONARY
 test_dictionary <- add_to_dictionary(test_dictionary,
-                                      option = "-99",
-                                      value  = "unknow",
-                                      grp    = "sex",
-                                      order  = NULL)
+  option = "-99",
+  value  = "unknow",
+  grp    = "sex",
+  order  = NULL
+)
 ```
 
 ```{r eval=TRUE, echo=FALSE}
@@ -695,10 +735,12 @@ cleaned_df <- clean_using_dictionary(
 cleaned_df %>%
   kableExtra::kbl() %>%
   kableExtra::kable_paper("striped", font_size = 14, full_width = TRUE) %>%
-  kableExtra::scroll_box(height = "200px", width = "100%",
-                         box_css = "border: 1px solid #ddd; padding: 5px; ",
-                         extra_css = NULL,
-                         fixed_thead = TRUE)
+  kableExtra::scroll_box(
+    height = "200px", width = "100%",
+    box_css = "border: 1px solid #ddd; padding: 5px; ",
+    extra_css = NULL,
+    fixed_thead = TRUE
+  )
 ```
 
 ## Calculating time span in different time scales (“years”, “months”, “weeks”, or “days”)
@@ -717,10 +759,14 @@ With these arguments, the function offers flexibility in determining the time sp
 ```{r eval=TRUE}
 # IMPORT DATA, REPLACE MISSING VALUES WITH 'NA' & STANDARDIZE DATES
 data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi")) %>%
-  replace_missing_values(target_columns = "dateOfBirth",
-                         na_strings     = "-99") %>%
-  standardize_dates(target_columns  = "dateOfBirth",
-                    error_tolerance = 0.0)
+  replace_missing_values(
+    target_columns = "dateOfBirth",
+    na_strings = "-99"
+  ) %>%
+  standardize_dates(
+    target_columns = "dateOfBirth",
+    error_tolerance = 0.0
+  )
 
 # CALCULATE INDIVIDUAL AGE IN YEARS FROM THE 'dateOfBirth' COLUMN AND SEND THE
 # REMAINDER IN MONTHS
@@ -736,8 +782,10 @@ age <- timespan(
 # CALCULATE THE TIME SPAN IN YEARS BETWEEN INDIVIDUALS 'dateOfBirth' AND THE DAY
 # THEY TESTED POSITIVE
 data <- readRDS(system.file("extdata", "test_df.RDS", package = "cleanepi")) %>%
-  replace_missing_values(target_columns = "dateOfBirth",
-                         na_strings     = "-99") %>%
+  replace_missing_values(
+    target_columns = "dateOfBirth",
+    na_strings = "-99"
+  ) %>%
   standardize_dates(
     target_columns  = c("dateOfBirth", "date_first_pcr_positive_test"),
     error_tolerance = 0.0
@@ -762,10 +810,12 @@ The `timespan()` function augments the input dataset by adding one or two extra 
 data %>%
   kableExtra::kbl() %>%
   kableExtra::kable_paper("striped", font_size = 14, full_width = TRUE) %>%
-  kableExtra::scroll_box(height = "200px", width = "100%",
-                         box_css = "border: 1px solid #ddd; padding: 5px; ",
-                         extra_css = NULL,
-                         fixed_thead = TRUE)
+  kableExtra::scroll_box(
+    height = "200px", width = "100%",
+    box_css = "border: 1px solid #ddd; padding: 5px; ",
+    extra_css = NULL,
+    fixed_thead = TRUE
+  )
 ```
 
 ## Printing the report

--- a/vignettes/design_principle.Rmd
+++ b/vignettes/design_principle.Rmd
@@ -27,8 +27,10 @@ Data cleaning is an important phase for ensuring the efficacy of downstream anal
 The {cleanepi} R package is designed to offer functional programming-style data cleansing tasks. To streamline the organization of data cleaning operations, we have categorized them into distinct groups referred to as **modules**. These modules are based on overarching goals derived from commonly anticipated data cleaning procedures. Each module features a primary function along with additional helper functions tailored to accomplish specific tasks. It's important to note that, except for few cases where the outcome a helper function can impact on the cleaning task, only the main function of each module will be exported. This deliberate choice empowers users to execute individual cleaning tasks as needed, enhancing flexibility and usability.
 
 ```{r echo=FALSE, comment="Figure1"}
-knitr::include_graphics(file.path("..", "man", "figures",
-                                  "cleanepi_design_diagram.drawio.png"))
+knitr::include_graphics(file.path(
+  "..", "man", "figures",
+  "cleanepi_design_diagram.drawio.png"
+))
 ```
 
 At the core of {cleanepi}, the pivotal function `clean_data()` serves as a wrapper encapsulating all the modules, as illustrated in the figure above. This function is intended to be the primary entry point for users seeking to cleanse their data. It performs the cleaning operations as requested by the user through the set of parameters that need to be explicitly defined. Furthermore, multiple cleaning operations can be performed sequentially using the “pipe” operator (`%>%`).


### PR DESCRIPTION
This PR runs `styler::style_pkg()` to style the codebase (according to the tidyverse specs). I am introducing this PR because:

* The package code style deviates from the general Epiverse-TRACE style
* This deviation is not documented and creates ambiguity as to what style is applied
* Because the style is not defined, it is unclear how to contribute in style code
* It is also unclear whether the style is applied consistently throughout the current codebase

By running `styler::style_pkg()` I am attempting to create a baseline and ensure that future contributions can be confident. In case this is not desirable, I would like to request explicit documentation as to what code style is applied (e.g., in the package vignette). I realize we do not have hard standards on this in the blueprints at this time, and I do think there is value in a consistent and clear code style for the code, the maintainer, and for the contributors.
