### PR TITLE
update print_report() function: account for when scan_data() is not e…

### DIFF
--- a/man/print_report.Rd
+++ b/man/print_report.Rd
@@ -50,15 +50,19 @@ cleaned_data <- data \%>\%
  replace_missing_values(target_columns = NULL, na_strings = "-99") \%>\%
  remove_constants(cutoff = 1.0) \%>\%
  remove_duplicates(target_columns = NULL) \%>\%
- standardize_dates(target_columns  = NULL,
-                   error_tolerance = 0.4,
-                   format          = NULL,
-                   timeframe   = as.Date(c("1973-05-29", "2023-05-29"))) \%>\%
- check_subject_ids(target_columns = "study_id",
-                   prefix         = "PS",
-                   suffix         = "P2",
-                   range          = c(1L, 100L),
-                   nchar          = 7L) \%>\%
+ standardize_dates(
+   target_columns = NULL,
+   error_tolerance = 0.4,
+   format = NULL,
+   timeframe = as.Date(c("1973-05-29", "2023-05-29"))
+ ) \%>\%
+ check_subject_ids(
+   target_columns = "study_id",
+   prefix = "PS",
+   suffix = "P2",
+   range = c(1L, 100L),
+   nchar = 7L
+ ) \%>\%
  convert_to_numeric(target_columns = "sex", lang = "en") \%>\%
  clean_using_dictionary(dictionary = test_dictionary)
 

--- a/tests/testthat/test-print_report.R
+++ b/tests/testthat/test-print_report.R
@@ -4,8 +4,7 @@ test_data <- readRDS(
 )
 
 test_dictionary <- readRDS(
-  system.file("extdata", "test_dictionary.RDS",
-  package = "cleanepi")
+  system.file("extdata", "test_dictionary.RDS", package = "cleanepi")
 )
 
 cleaned_data <- test_data %>%
@@ -44,11 +43,11 @@ test_that("print_report works", {
   testthat::skip_on_cran()
   testthat::skip_on_covr()
   test_print_report <- print_report(
-    data             = cleaned_data,
-    report_title     = "{cleanepi} data cleaning report",
+    data = cleaned_data,
+    report_title = "{cleanepi} data cleaning report",
     output_file_name = NULL,
-    format           = "html",
-    print            = FALSE
+    format = "html",
+    print = FALSE
   )
   expect_type(test_print_report, "character")
   expect_true(file.exists(test_print_report))
@@ -61,24 +60,23 @@ test_that("print_report fails when no report is associated to the data", {
   testthat::skip_on_covr()
   expect_error(
     print_report(
-      data             = test_data,
-      report_title     = "{cleanepi} data cleaning report",
+      data = test_data,
+      report_title = "{cleanepi} data cleaning report",
       output_file_name = NULL,
-      format           = "html",
-      print            = FALSE
+      format = "html",
+      print = FALSE
     ),
-    regexp = cat("The input data for 'print_report()' must be subjected to
-                 some cleaning operations to have a report associated to it.")
+    regexp = cat("No report associated with the input data.")
   )
 
   expect_error(
     print_report(
-      data             = test_data,
-      report_title     = "{cleanepi} data cleaning report",
+      data = test_data,
+      report_title = "{cleanepi} data cleaning report",
       output_file_name = NULL,
-      format           = "pdf",
-      print            = FALSE
+      format = "pdf",
+      print = FALSE
     ),
-    regexp = cat("The PDF format is not currently supported.")
+    regexp = cat("Invalid format: Only 'html' format is currently supported.")
   )
 })


### PR DESCRIPTION
Changes in this PR aims at addressing issue #192 

`scan_data()` returns `NA` when there is no character column found from the input data. I have set `scanning_result = NA` in the `print_report()` function. This will prevent from the error detected by @avallecam when `print_report()` is given a dataset where `scan_data()` was not applied to.
