### PR TITLE
add {systemfonts} as a dependency in Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,6 +63,7 @@ Suggests:
     reactable,
     rmarkdown,
     spelling,
+    systemfonts,
     testthat (>= 3.0.0)
 VignetteBuilder: 
     knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # cleanepi (development version)
 
+# cleanepi 1.1.1
+
+## Bug fixes
+
+* Added {systemfonts} as a dependency in Suggests as it is required to build the
+vignette in **r-oldrel-macos-arm64** (#218, @Karim-Mane).
+
 # cleanepi 1.1.0
 
 ## Bug fixes

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -29,12 +29,14 @@ lifecycle
 linelist
 lintr
 lubridate
+macos
 magrittr
 modelling
 na
 naniar
 nchar
 numberize
+oldrel
 packagename
 pcr
 potools
@@ -45,6 +47,7 @@ repo
 rlang
 rmarkdown
 snakecase
+systemfonts
 testthat
 tibble
 tibbles

--- a/vignettes/design_principle.Rmd
+++ b/vignettes/design_principle.Rmd
@@ -312,6 +312,7 @@ The functions will require other packages that are needed in the package develop
 
 [{checkmate}](https://CRAN.R-project.org/package=checkmate), [{kableExtra}](https://CRAN.R-project.org/package=kableExtra), [{bookdown}](https://CRAN.R-project.org/package=bookdown), [{rmarkdown}](https://CRAN.R-project.org/package=rmarkdown), [{testthat}](https://CRAN.R-project.org/package=testthat) (\>= 3.0.0), [{knitr}](https://CRAN.R-project.org/package=knitr), [{lintr}](https://CRAN.R-project.org/package=lintr),
 [{potools}](https://CRAN.R-project.org/package=potools)
+[{systemfonts}](https://CRAN.R-project.org/package=systemfonts)
 
 ## Contribute
 


### PR DESCRIPTION
This PR contains changes to fix an error from the [CRAN check results](https://cran.r-project.org/web/checks/check_results_cleanepi.html) of {cleanepi} version 1.1.0.

  

- [x]  {systemfonts} has been added as a dependency in Suggests
- [x]  update NEWS.md after PR #216 is merged into main
- [x]  update the package design vignette with the new dependency


