### PR TITLE
Fix issue 223

### DIFF
--- a/R/standardize_date.R
+++ b/R/standardize_date.R
@@ -112,7 +112,11 @@ standardize_dates <- function(data,
                               format = NULL,
                               timeframe = NULL,
                               error_tolerance = 0.4,
-                              orders = NULL) {
+                              orders = list(
+                                world_named_months = c("Ybd", "dby"),
+                                world_digit_months = c("dmy", "Ymd"),
+                                US_formats = c("Omdy", "YOmd")
+                              )) {
 
   checkmate::assert_data_frame(data, null.ok = FALSE, min.cols = 1L)
   checkmate::assert_character(target_columns, null.ok = TRUE,

--- a/man/standardize_dates.Rd
+++ b/man/standardize_dates.Rd
@@ -10,7 +10,8 @@ standardize_dates(
   format = NULL,
   timeframe = NULL,
   error_tolerance = 0.4,
-  orders = NULL
+  orders = list(world_named_months = c("Ybd", "dby"), world_digit_months = c("dmy",
+    "Ymd"), US_formats = c("Omdy", "YOmd"))
 )
 }
 \arguments{


### PR DESCRIPTION
This PR contains changes to fix issue #223. They include:

* set a default value for the `orders` argument of the `standardize_dates()` function. The value in version 1.0.2 is used.
* update the function documentation and NEWS.md file.
