### PR TITLE
Fix issue #226

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -3,6 +3,7 @@ linters: all_linters(
     pipe_consistency_linter(pipe = "%>%"),
     object_name_linter = NULL,
     one_call_pipe_linter = NULL,
+    return_linter = NULL,
     implicit_integer_linter = NULL,
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,

--- a/.lintr
+++ b/.lintr
@@ -2,6 +2,7 @@ linters: all_linters(
     packages = c("lintr", "etdev"),
     pipe_consistency_linter(pipe = "%>%"),
     object_name_linter = NULL,
+    one_call_pipe_linter = NULL,
     implicit_integer_linter = NULL,
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,13 @@ vignette in **r-oldrel-macos-arm64** (#218, @Karim-Mane).
 * Set a default value for the `orders` argument of the `standardize_dates()`
 function using its initial value in version 1.0.2 (#224, @Karim-Mane).
 
+## Enhancements
+
+* The values of the `duplicates_checked_from`, `converted_into_numeric`,
+`missing_values_replaced_at`, `missing_ids` elements of the report which used to
+be a character (a comma-separated list of values) are now of type vector
+(#228, @Karim-Mane).
+
 # cleanepi 1.1.0
 
 ## Bug fixes

--- a/R/convert_to_numeric.R
+++ b/R/convert_to_numeric.R
@@ -73,7 +73,7 @@ convert_to_numeric <- function(data, target_columns = NULL,
   data <- add_to_report(
     x = data,
     key = "converted_into_numeric",
-    value = toString(target_columns)
+    value = target_columns
   )
   return(data)
 }

--- a/R/find_and_remove_duplicates.R
+++ b/R/find_and_remove_duplicates.R
@@ -125,7 +125,7 @@ find_duplicates <- function(data, target_columns = NULL) {
     data <- add_to_report(
       x = data,
       key = "duplicates_checked_from",
-      value = toString(target_columns)
+      value = target_columns
     )
   } else {
     cli::cli_alert_info(

--- a/R/find_and_remove_duplicates.R
+++ b/R/find_and_remove_duplicates.R
@@ -53,8 +53,8 @@ remove_duplicates <- function(data, target_columns = NULL) {
   if ("duplicated_rows" %in% names(tmp_report) &&
       nrow(tmp_report[["duplicated_rows"]]) > 0L) {
     tmp_target_columns <- c("row_id", target_columns)
-    to_be_removed <- suppressMessages(dplyr::anti_join(dups, dat) %>%
-        dplyr::select({{ tmp_target_columns }}))
+    to_be_removed <- suppressMessages(dplyr::anti_join(dups, dat)) %>%
+        dplyr::select({{ tmp_target_columns }})
     report[["removed_duplicates"]] <- to_be_removed
   }
 

--- a/R/replace_missing_values.R
+++ b/R/replace_missing_values.R
@@ -48,7 +48,7 @@ replace_missing_values <- function(data,
     data <- add_to_report(
       x = data,
       key = "missing_values_replaced_at",
-      value = toString(cols)
+      value = cols
     )
   } else {
     cli::cli_inform(c(

--- a/R/standardize_subject_ids.R
+++ b/R/standardize_subject_ids.R
@@ -198,7 +198,7 @@ check_subject_ids_oness <- function(data, id_col_name) {
     data <- add_to_report(
       x = data,
       key = "missing_ids",
-      value = toString(idx)
+      value = idx
     )
   }
 

--- a/R/standardize_subject_ids.R
+++ b/R/standardize_subject_ids.R
@@ -80,7 +80,7 @@ check_subject_ids <- function(data,
 
   # detect subject IDs where the number of characters is not as expected
   if (!is.null(nchar)) {
-    bad_rows <- c(bad_rows, which(!nchar(data[[target_columns]]) == nchar))
+    bad_rows <- c(bad_rows, which(nchar(data[[target_columns]]) != nchar))
   }
 
   # when all subject ids comply with the expected format,

--- a/inst/rmarkdown/templates/printing-rmd/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/printing-rmd/skeleton/skeleton.Rmd
@@ -420,7 +420,10 @@ reactable::reactable(
 ### Missing value replaced with NA
 
 ```{r use_na, eval=are_missing_values_replaced}
-missing_values_replaced_at <- data.frame(toString(missing_values_replaced_at))
+missing_values_replaced_at <- data.frame(
+  toString(missing_values_replaced_at),
+  stringsAsFactors = FALSE
+)
 names(missing_values_replaced_at) <- "missing values replaced with NA at"
 reactable::reactable(
   missing_values_replaced_at,

--- a/inst/rmarkdown/templates/printing-rmd/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/printing-rmd/skeleton/skeleton.Rmd
@@ -420,9 +420,8 @@ reactable::reactable(
 ### Missing value replaced with NA
 
 ```{r use_na, eval=are_missing_values_replaced}
-missing_values_replaced_at <- glue::glue_collapse(missing_values_replaced_at,
-                                                  sep = ", ")
-missing_values_replaced_at <- data.frame(missing_values_replaced_at)
+missing_values_replaced_at <- data.frame(toString(missing_values_replaced_at))
+names(missing_values_replaced_at) <- "missing values replaced with NA at"
 reactable::reactable(
   missing_values_replaced_at,
   sortable   = FALSE,
@@ -479,8 +478,8 @@ reactable::reactable(
 #### Missing ids
 
 ```{r missing_ids, eval=are_missing_ids}
-missing_ids            <- data.frame(missing_ids)
-colnames(missing_ids)  <- "row indices"
+missing_ids <- data.frame(toString(missing_ids))
+colnames(missing_ids) <- "row indices"
 row.names(missing_ids) <- "missing ids"
 reactable::reactable(
   missing_ids,
@@ -533,5 +532,22 @@ reactable::reactable(
 )
 ```
 
+### Columns converted into numeric {.tabset}
+
+```{r cols_converted_to_num, eval=are_converted_into_numeric}
+converted_into_numeric <- data.frame(toString(converted_into_numeric))
+names(converted_into_numeric) <- "columns converted into numeric"
+reactable::reactable(
+  converted_into_numeric,
+  sortable   = FALSE,
+  filterable = FALSE,
+  searchable = FALSE,
+  pagination = FALSE,
+  rownames   = FALSE,
+  striped    = TRUE,
+  compact    = TRUE,
+  fullWidth  = TRUE
+)
+```
 
 ## Aggregated data {.tabset}

--- a/inst/rmarkdown/templates/printing-rmd/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/printing-rmd/skeleton/skeleton.Rmd
@@ -478,7 +478,7 @@ reactable::reactable(
 #### Missing ids
 
 ```{r missing_ids, eval=are_missing_ids}
-missing_ids <- data.frame(toString(missing_ids))
+missing_ids <- data.frame(toString(missing_ids), stringsAsFactors = FALSE)
 colnames(missing_ids) <- "row indices"
 row.names(missing_ids) <- "missing ids"
 reactable::reactable(
@@ -535,7 +535,10 @@ reactable::reactable(
 ### Columns converted into numeric {.tabset}
 
 ```{r cols_converted_to_num, eval=are_converted_into_numeric}
-converted_into_numeric <- data.frame(toString(converted_into_numeric))
+converted_into_numeric <- data.frame(
+  toString(converted_into_numeric),
+  stringsAsFactors = FALSE
+)
 names(converted_into_numeric) <- "columns converted into numeric"
 reactable::reactable(
   converted_into_numeric,


### PR DESCRIPTION
This PR contains changes to address issue #226. The changes include:

* returning a vector of target columns (instead of a comma-separated strings) for the `duplicates_checked_from` element of the report generated by the `find_duplicates()` or `remove_duplicates()` functions.
* update the NEWS.md file
