### PR TITLE
fix check_date_sequence: account for the presence of missing values

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -5,7 +5,7 @@ linters: all_linters(
     one_call_pipe_linter = NULL,
     return_linter = NULL,
     implicit_integer_linter = NULL,
-    extraction_operator_linter = NULL,
+    # extraction_operator_linter = NULL,
     one_call_pipe_linter = NULL,
     todo_comment_linter = NULL,
     library_call_linter = NULL,

--- a/R/check_date_sequence.R
+++ b/R/check_date_sequence.R
@@ -88,7 +88,7 @@ check_date_sequence <- function(data, target_columns) {
 
   # send a message that sequence of date events can not be checked in a certain
   # number of rows due to missing values
-  if (any(is.na(order_date))) {
+  if (anyNA(order_date)) {
     cli::cli_alert_info(c(
       tr_("Cannot check the sequence of date events across {.val {sum(is.na(order_date))}} rows due to missing data.") # nolint: line_length_linter
     ))

--- a/R/check_date_sequence.R
+++ b/R/check_date_sequence.R
@@ -77,7 +77,7 @@ check_date_sequence <- function(data, target_columns) {
   order_date <- apply(tmp_data, 1L, is_date_sequence_ordered)
   tmp_data[["row_id"]] <- seq_len(nrow(tmp_data))
 
-  # send a message if the comparison could not be archive due to missing
+  # send a message if the comparison could not be achieved due to missing
   # values in either of the columns
   if (all(is.na(order_date))) {
     cli::cli_alert_info(

--- a/R/check_date_sequence.R
+++ b/R/check_date_sequence.R
@@ -75,7 +75,7 @@ check_date_sequence <- function(data, target_columns) {
   # and checking the date sequence
   tmp_data <- data %>% dplyr::select(dplyr::all_of(target_columns))
   order_date <- apply(tmp_data, 1L, is_date_sequence_ordered)
-  tmp_data[["row_id"]] <- 1:nrow(tmp_data)
+  tmp_data[["row_id"]] <- seq_len(nrow(tmp_data))
 
   # send a message if the comparison could not be archive due to missing
   # values in either of the columns

--- a/R/check_date_sequence.R
+++ b/R/check_date_sequence.R
@@ -72,7 +72,7 @@ check_date_sequence <- function(data, target_columns) {
 
   # select the target columns
   # add a column with the row indices
-  # and checking the date sequence
+  # and check the order of the date sequence
   tmp_data <- data %>% dplyr::select(dplyr::all_of(target_columns))
   order_date <- apply(tmp_data, 1L, is_date_sequence_ordered)
   tmp_data[["row_id"]] <- seq_len(nrow(tmp_data))

--- a/R/column_name_standardization.R
+++ b/R/column_name_standardization.R
@@ -128,8 +128,8 @@ standardize_column_names <- function(data, keep = NULL, rename = NULL) {
 make_unique_column_names <- function(after, kept, before, rename) {
   # detect those that are similar to the ones we want to keep or rename
   # make them unique
-  t <- table(after)
-  duplicates <- names(t[t > 1])
+  tab <- table(after)
+  duplicates <- names(tab[tab > 1])
 
   # do not proceed if there is no duplicates
   if (length(duplicates) == 0) {
@@ -171,7 +171,7 @@ make_unique_column_names <- function(after, kept, before, rename) {
         reference <- max(are_numeric, na.rm = TRUE)
         add <- seq_len(sum(sizes == 1) + 1)
         after[are_duplicates][sizes == 1] <- paste0(
-          dup, "_", add[!(add == reference)]
+          dup, "_", add[add != reference]
         )
       }
     }

--- a/R/date_standardization_helpers.R
+++ b/R/date_standardization_helpers.R
@@ -309,8 +309,8 @@ date_detect_complex_format <- function(x) {
   if (all(is.null(c(f1, f2)))) {
     return(NULL)
   }
-  format <- paste(c(f1, f2), collapse = tmp_sep)
-  return(format)
+  formats <- paste(c(f1, f2), collapse = tmp_sep)
+  return(formats)
 }
 
 #' Detect a date format with only 1 separator
@@ -458,9 +458,9 @@ date_get_format <- function(x) {
 
   # when there is a missing value (NA) or a shorter element in the list, repeat
   # complete it with NA to get the same length across all elements of the list
-  lengths <- as.numeric(lapply(tmp_list, length))
+  var_lengths <- as.numeric(lapply(tmp_list, length))
   add_na <- function(y, n) return(c(y, rep(NA, n - length(y))))
-  tmp_list <- lapply(tmp_list, add_na, max(lengths))
+  tmp_list <- lapply(tmp_list, add_na, max(var_lengths))
 
   # split all elements of the list based on "-" and store the different parts
   # in separate object. Each part is subjected to the date guesser:
@@ -497,8 +497,8 @@ date_get_format <- function(x) {
   f1 <- if (all(is.na(part1))) NA else date_detect_format(part1)
   f2 <- if (all(is.na(part2))) NA else date_detect_format(part2)
   f3 <- if (all(is.na(part3))) NA else date_detect_format(part3)
-  format <- date_make_format(f1, f2, f3)
-  return(format)
+  formats <- date_make_format(f1, f2, f3)
+  return(formats)
 }
 
 #' Build the auto-detected format
@@ -522,12 +522,12 @@ date_make_format <- function(f1, f2, f3) {
   if (verdict) {
     return(NULL)
   }
-  format <- NULL
+  formats <- NULL # nolint: object_usage_linter
   idx <- which(is.na(c(f1, f2, f3)))
   if (length(idx) == 0L) {
-    format <- paste0(format, f1, "-", f2, "-", f3)
+    formats <- paste0(format, f1, "-", f2, "-", f3)
   } else if (idx == 3L) {
-    format <- paste0(format, f1, "-", f2)
+    formats <- paste0(format, f1, "-", f2)
   } else {
     return(NULL)
   }

--- a/R/guess_dates.R
+++ b/R/guess_dates.R
@@ -237,11 +237,11 @@ date_rescue_lubridate_failures <- function(date_a_frame, original_dates,
 #' @keywords internal
 date_i_guess_and_convert <- function(x) {
   x <- as.character(x)
-  format <- date_get_format(x)
-  if (is.null(format)) {
+  formats <- date_get_format(x)
+  if (is.null(formats)) {
     return(NA_character_)
   }
-  x <- as.character(as.Date(x, format = format))
+  x <- as.character(as.Date(x, format = formats))
   return(x)
 }
 

--- a/po/R-cleanepi.pot
+++ b/po/R-cleanepi.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: cleanepi 1.0.2.9000\n"
-"POT-Creation-Date: 2025-02-07 11:26+0000\n"
+"Project-Id-Version: cleanepi 1.1.0.9000\n"
+"POT-Creation-Date: 2025-05-27 20:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,36 +10,47 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: check_date_sequence.R:57
+#: check_date_sequence.R:58
 msgid ""
 "Found the following unrecognised column name{?s}: {.field "
 "{target_columns[missing_cols]}}."
 msgstr ""
 
-#: check_date_sequence.R:65
+#: check_date_sequence.R:66
 msgid "Insufficient number of columns to compare."
 msgstr ""
 
-#: check_date_sequence.R:66
+#: check_date_sequence.R:67
 msgid ""
 "At least two columns of type {.cls Date} are required for this operation."
 msgstr ""
 
-#: check_date_sequence.R:67
+#: check_date_sequence.R:68
 msgid "Have you provided an invalid column name?"
 msgstr ""
 
-#: check_date_sequence.R:80
+#: check_date_sequence.R:84
+msgid ""
+"Impossible to check the sequence of the date events due to missing values."
+msgstr ""
+
+#: check_date_sequence.R:93
+msgid ""
+"Cannot check the sequence of date events across {.val {sum(is."
+"na(order_date))}} rows due to missing data."
+msgstr ""
+
+#: check_date_sequence.R:103
 msgid "No incorrect date sequence was detected."
 msgstr ""
 
-#: check_date_sequence.R:100
+#: check_date_sequence.R:120
 msgid ""
 "Detected {.val {length(bad_order)}} incorrect date sequence{?s} at line{?s}: "
 "{.val {toString(bad_order)}}."
 msgstr ""
 
-#: check_date_sequence.R:101
+#: check_date_sequence.R:121
 msgid ""
 "Enter {.code attr(dat, \"report\")[[\"incorrect_date_sequence\"]]} to access "
 "them, where {.val dat} is the object used to store the output from this "
@@ -96,107 +107,107 @@ msgstr ""
 msgid "Checking whether date sequences are respected"
 msgstr ""
 
-#: clean_data_helpers.R:70
+#: clean_data_helpers.R:72
 msgid "No character column found from the input data."
 msgstr ""
 
-#: clean_data_helpers.R:91
+#: clean_data_helpers.R:93
 msgid ""
 "Found {.cls numeric} values that can also be of type {.cls Date} in the "
 "following {cli::qty(length(ambiguous_cols))} column{?s}: {.field "
 "{toString(ambiguous_cols)}}."
 msgstr ""
 
-#: clean_data_helpers.R:92
+#: clean_data_helpers.R:94
 msgid ""
 "They can be converted into {.cls Date} using: {.code lubridate::as_date(x, "
 "origin = as.Date(\"1900-01-01\"))}"
 msgstr ""
 
-#: clean_data_helpers.R:93
+#: clean_data_helpers.R:95
 msgid ""
 "where {.val x} represents here the vector of values from the corresponding "
 "column ({.code data$target_column})."
 msgstr ""
 
-#: column_name_standardization.R:58
+#: column_name_standardization.R:59
 msgid ""
 "Cannot rename {cli::qty(length(incorrect_col_names))} {?an/ } unrecognised "
 "column name{?s} specified in {.emph rename} argument: {.val "
 "{toString(incorrect_col_names)}}."
 msgstr ""
 
-#: column_name_standardization.R:59
+#: column_name_standardization.R:60
 msgid "Make sure that the columns to be renamed are part of the input data."
 msgstr ""
 
-#: column_name_standardization.R:60
+#: column_name_standardization.R:61
 msgid ""
 "To rename columns, use: {.emph rename = c(new_name1 = 'old_name1', new_name2 "
 "= 'old_name2')}."
 msgstr ""
 
-#: column_name_standardization.R:68
+#: column_name_standardization.R:69
 msgid ""
 "The provided replace column {cli::qty(length(existing_cols))} name{?s} "
 "already exist."
 msgstr ""
 
-#: column_name_standardization.R:69
+#: column_name_standardization.R:70
 msgid "All new names must be different from existing column names."
 msgstr ""
 
-#: column_name_standardization.R:70
+#: column_name_standardization.R:71
 msgid ""
 "You must use {cli::qty(length(existing_cols))} {?a/ } different name{?s} for "
 "the following column{?s}: {.field {toString(existing_cols)}}."
 msgstr ""
 
-#: convert_to_numeric.R:40
+#: convert_to_numeric.R:42
 msgid "Automatic detection of columns to convert into numeric failed."
 msgstr ""
 
-#: convert_to_numeric.R:41
+#: convert_to_numeric.R:43
 msgid "No character column with numeric values found by {.fn scan_data}."
 msgstr ""
 
-#: convert_to_numeric.R:42 convert_to_numeric.R:64
+#: convert_to_numeric.R:44 convert_to_numeric.R:66
 msgid ""
 "Please specify names of the columns to convert into numeric using {.emph "
 "target_columns}."
 msgstr ""
 
-#: convert_to_numeric.R:62
+#: convert_to_numeric.R:64
 msgid ""
 "Found one or more columns with insuffisient numeric values for automatic "
 "conversion."
 msgstr ""
 
-#: convert_to_numeric.R:63
+#: convert_to_numeric.R:65
 msgid ""
-"The percent of character values must be less than twice the numeric values "
-"for a column to be considered for automatic conversion."
-msgstr ""
-
-#: convert_to_numeric.R:105
-msgid "Found {.val {num_values}} numeric value{?s} in {.field {col}}."
-msgstr ""
-
-#: convert_to_numeric.R:106
-msgid "Please consider the following options:"
+"The percentage of character values must be less than twice the numeric "
+"values for a column to be considered for automatic conversion."
 msgstr ""
 
 #: convert_to_numeric.R:107
-msgid "Converting characters into numeric"
+msgid "Found {.val {num_values}} numeric value{?s} in {.field {col}}."
 msgstr ""
 
 #: convert_to_numeric.R:108
+msgid "Please consider the following options:"
+msgstr ""
+
+#: convert_to_numeric.R:109
+msgid "Converting characters into numeric"
+msgstr ""
+
+#: convert_to_numeric.R:110
 msgid ""
 "Replacing the numeric values by {.val NA} using the {.fn "
 "replace_missing_values} function."
 msgstr ""
 
-#: convert_to_numeric.R:115
+#: convert_to_numeric.R:117
 msgid ""
 "The following column{?s} will be converted into numeric: {.field "
 "{to_numeric}}."
@@ -213,51 +224,51 @@ msgid ""
 "31, 2024)."
 msgstr ""
 
-#: date_standardization_helpers.R:410
+#: date_standardization_helpers.R:412
 msgid "Expected values with the same format."
 msgstr ""
 
-#: date_standardization_helpers.R:411
+#: date_standardization_helpers.R:413
 msgid "You've tried to convert values in different formats into {.cls Date}."
 msgstr ""
 
-#: date_standardization_helpers.R:412
+#: date_standardization_helpers.R:414
 msgid ""
 "Please specify the formats encountered in your column of interest via the {."
 "emph format} argument."
 msgstr ""
 
-#: date_standardization_helpers.R:553
+#: date_standardization_helpers.R:556
 msgid "Unexpected data type provided to {.fn date_guess} function."
 msgstr ""
 
-#: date_standardization_helpers.R:554
+#: date_standardization_helpers.R:557
 msgid ""
 "You can convert the values into {.cls character} to enable format guessing."
 msgstr ""
 
-#: date_standardization_helpers.R:555
+#: date_standardization_helpers.R:558
 msgid ""
 "You've tried to guess the date format from values of type other than Date "
 "and character."
 msgstr ""
 
-#: date_standardization_helpers.R:574
+#: date_standardization_helpers.R:578
 msgid "Unable to match formats to target columns."
 msgstr ""
 
-#: date_standardization_helpers.R:575
+#: date_standardization_helpers.R:579
 msgid ""
 "The number of target columns does not match the number of specified formats."
 msgstr ""
 
-#: date_standardization_helpers.R:576
+#: date_standardization_helpers.R:580
 msgid ""
 "Only one format is needed if all target columns contain values of the same "
 "format. Otherwise, one format per target column must be provided."
 msgstr ""
 
-#: date_standardization_helpers.R:581
+#: date_standardization_helpers.R:585
 msgid ""
 "The target {cli::qty(length(target_columns))} column{?s} will be "
 "standardized using the format: {.val {format}}."
@@ -281,257 +292,257 @@ msgstr ""
 msgid "Run {.fn get_default_params} to display the list of default parameters."
 msgstr ""
 
-#: dictionary_based_cleaning.R:48
+#: dictionary_based_cleaning.R:49
 msgid "Incorrect data dictionary format."
 msgstr ""
 
-#: dictionary_based_cleaning.R:49
+#: dictionary_based_cleaning.R:50
 msgid ""
 "The value for the {.emph dictionary} argument must be a {.cls data.frame} "
 "with the following columns: {.field {toString(all_columns)}}."
 msgstr ""
 
-#: dictionary_based_cleaning.R:50
+#: dictionary_based_cleaning.R:51
 msgid ""
 "The following columns are mandatory: {.field {toString(mandatory_columns)}}."
 msgstr ""
 
-#: dictionary_based_cleaning.R:58
+#: dictionary_based_cleaning.R:59
 msgid ""
 "Incorrect column names specified in column {.field grp} of the data "
 "dictionary."
 msgstr ""
 
-#: dictionary_based_cleaning.R:59
+#: dictionary_based_cleaning.R:60
 msgid ""
 "Values in {.field grp} column of the data dictionary must be found in the "
 "input data frame."
 msgstr ""
 
-#: dictionary_based_cleaning.R:60
+#: dictionary_based_cleaning.R:61
 msgid "Did you enter an incorrect column name?"
 msgstr ""
 
-#: dictionary_based_cleaning.R:71
+#: dictionary_based_cleaning.R:72
 msgid "You can either:"
 msgstr ""
 
-#: dictionary_based_cleaning.R:72
+#: dictionary_based_cleaning.R:73
 msgid ""
 "correct the misspelled {cli::qty(length(misspelled_options))} option{?s} "
 "from the input data, or"
 msgstr ""
 
-#: dictionary_based_cleaning.R:73
+#: dictionary_based_cleaning.R:74
 msgid ""
 "add {cli::qty(length(misspelled_options))} {?it/them} to the dictionary "
 "using the {.fn add_to_dictionary} function."
 msgstr ""
 
-#: dictionary_based_cleaning.R:298
+#: dictionary_based_cleaning.R:255
 msgid ""
 "Cannot replace {.val {toString(undefined_opts)}} present in column {.field "
 "{opts}} but not defined in the dictionary."
 msgstr ""
 
-#: find_and_remove_duplicates.R:115
+#: find_and_remove_duplicates.R:118
 msgid "Found {.val {nrow(dups)}} duplicated row{?s} in the dataset."
 msgstr ""
 
-#: find_and_remove_duplicates.R:116
+#: find_and_remove_duplicates.R:119
 msgid ""
 "Use {.code attr(dat, \"report\")[[\"duplicated_rows\"]]} to access them, "
 "where {.val dat} is the object used to store the output from this operation."
 msgstr ""
 
-#: find_and_remove_duplicates.R:132
+#: find_and_remove_duplicates.R:135
 msgid "No duplicates were found."
 msgstr ""
 
-#: guess_dates.R:85
+#: guess_dates.R:86
 msgid "Incorrect value provided to the {.emph order} argument."
 msgstr ""
 
-#: guess_dates.R:86
+#: guess_dates.R:87
 msgid ""
 "Value for {.emph order} argument must be either a {.cls character} or a {."
 "cls list} of character vectors."
 msgstr ""
 
-#: print_report.R:78
+#: print_report.R:81
 msgid "No report associated with the input data."
 msgstr ""
 
-#: print_report.R:79
+#: print_report.R:82
 msgid ""
 "At least one data cleaning operation must be applied to the data before "
 "calling {.fn print_report}."
 msgstr ""
 
-#: print_report.R:80
+#: print_report.R:83
 msgid ""
 "The list of functions in {.pkg cleanepi} can be found at: {.url https://"
 "epiverse-trace.github.io/cleanepi/reference/index.html}."
 msgstr ""
 
-#: print_report.R:85
+#: print_report.R:88
 msgid "Incorrect value provided for {.emph format} argument!"
 msgstr ""
 
-#: print_report.R:86
+#: print_report.R:89
 msgid "Only {.val html} format is currently supported."
 msgstr ""
 
-#: print_report.R:112
+#: print_report.R:115
 msgid "Generating html report in {.file {temp_dir}}."
 msgstr ""
 
-#: remove_constants.R:122
+#: remove_constants.R:124
 msgid ""
 "Constant data was removed after {.val {nrow(constant_data_report)}} "
 "iteration{?s}."
 msgstr ""
 
-#: remove_constants.R:123
+#: remove_constants.R:125
 msgid ""
 "Enter {.code attr(dat, \"report\")[[\"constant_data\"]]} for more "
 "information, where {.val dat} represents the object used to store the output "
 "from {.fn remove_constants}."
 msgstr ""
 
-#: replace_missing_values.R:56
+#: replace_missing_values.R:55
 msgid ""
 "Could not detect the provided missing value {cli::qty(length(na_strings))} "
 "character{?s}."
 msgstr ""
 
-#: replace_missing_values.R:57
+#: replace_missing_values.R:56
 msgid ""
 "Does your data contain missing value characters other than the specified "
 "ones?"
 msgstr ""
 
-#: span.R:85
+#: span.R:88
 msgid "Unexpected type in the value for argument {.emph end_date}."
 msgstr ""
 
-#: span.R:86
+#: span.R:89
 msgid ""
 "You provided a name of a column of type {.cls {class(data[[end_date]])}}."
 msgstr ""
 
-#: span.R:87
+#: span.R:90
 msgid ""
 "The value for {.emph end_date} argument must be of type {.cls Date} in {."
 "emph ISO8601} format."
 msgstr ""
 
-#: standardize_date.R:184
+#: standardize_date.R:190
 msgid ""
 "Found {.cls numeric} values that could also be of type {.cls Date} in {cli::"
 "qty(length(ambiguous_cols))} column{?s}: {.field {toString(ambiguous_cols)}}."
 msgstr ""
 
-#: standardize_date.R:185
+#: standardize_date.R:191
 msgid ""
 "It is possible to convert them into {.cls Date} using: {.code lubridate::"
 "as_date(x, origin = as.Date(\"1900-01-01\"))}"
 msgstr ""
 
-#: standardize_date.R:186
+#: standardize_date.R:192
 msgid ""
 "where {.val x} represents here the vector of values from these columns ({."
 "code data$target_column})."
 msgstr ""
 
-#: standardize_subject_ids.R:87
+#: standardize_subject_ids.R:90
 msgid "No incorrect subject id was detected."
 msgstr ""
 
-#: standardize_subject_ids.R:100
+#: standardize_subject_ids.R:103
 msgid ""
 "Detected {.val {length(bad_rows)}} invalid subject id{?s} at line{?s}: {.val "
 "{toString(bad_rows)}}."
 msgstr ""
 
-#: standardize_subject_ids.R:101
+#: standardize_subject_ids.R:104
 msgid ""
 "You can use the {.fn correct_subject_ids} function to correct {cli::"
 "qty(length(bad_rows))} {?it/them}."
 msgstr ""
 
-#: standardize_subject_ids.R:163
+#: standardize_subject_ids.R:166
 msgid ""
-"Some ids specified in the correction table were not found in the input data."
+"Some IDs specified in the correction table were not found in the input data."
 msgstr ""
 
-#: standardize_subject_ids.R:164
+#: standardize_subject_ids.R:167
 msgid ""
 "Values in the {.field from} column of the correction table must be part of "
-"the detected incorrect subject ids."
+"the detected incorrect subject IDs."
 msgstr ""
 
-#: standardize_subject_ids.R:192
+#: standardize_subject_ids.R:196
 msgid ""
 "Missing {cli::qty(length(idx))} value{?s} found in {.field {id_col_name}} "
 "column at line{?s}: {.val {toString(idx)}}."
 msgstr ""
 
-#: standardize_subject_ids.R:209
-msgid "Found {.val {num_dup_rows}} duplicated value{?s} in the subject ids."
+#: standardize_subject_ids.R:213
+msgid "Found {.val {num_dup_rows}} duplicated value{?s} in the subject Ids."
 msgstr ""
 
-#: standardize_subject_ids.R:210
+#: standardize_subject_ids.R:214
 msgid ""
 "Enter {.code attr(dat, \"report\")[[\"duplicated_rows\"]]} to access them, "
 "where {.val dat} is the object used to store the output from this operation."
 msgstr ""
 
-#: utils.R:147
+#: utils.R:133
 msgid ""
 "Could not find the following column name{?s}: {.field {target_columns[is."
 "na(idx)]}}"
 msgstr ""
 
-#: utils.R:148
+#: utils.R:134
 msgid ""
 "Please make sure that all specified target columns belong to the input data."
 msgstr ""
 
-#: utils.R:159
+#: utils.R:145
 msgid "Some column indices are out of bound."
 msgstr ""
 
-#: utils.R:160
+#: utils.R:146
 msgid "Column indices must be between {.val {1}} and {.val {ncol(data)}}."
 msgstr ""
 
-#: utils.R:161
+#: utils.R:147
 msgid "You provided indices for columns that do not exist."
 msgstr ""
 
-#: utils.R:171
+#: utils.R:157
 msgid "Invalid value for {.emph target_columns}."
 msgstr ""
 
-#: utils.R:172
+#: utils.R:158
 msgid ""
 "{.val linelist_tags} only works on {.cls linelist} objects. You can provide "
 "a {.cls vector} of column names for inputs of class {.cls data.frame}."
 msgstr ""
 
-#: utils.R:186
+#: utils.R:172
 msgid "The specified target columns are either constant or empty."
 msgstr ""
 
-#: utils.R:187
+#: utils.R:173
 msgid "Please consider using:"
 msgstr ""
 
-#: utils.R:188
+#: utils.R:174
 msgid "the names of columns that are neither constant or empty, or"
 msgstr ""
 
-#: utils.R:189
+#: utils.R:175
 msgid "{.fn remove_constants} prior to this cleaning operation."
 msgstr ""

--- a/po/R-fr.po
+++ b/po/R-fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: cleanepi 1.0.2.9000\n"
-"POT-Creation-Date: 2025-02-07 11:26+0000\n"
+"POT-Creation-Date: 2025-05-27 20:14+0000\n"
 "PO-Revision-Date: 2024-11-07 12:38+0000\n"
 "Last-Translator: Karim Mané\n"
 "Language-Team: none\n"
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: check_date_sequence.R:57
+#: check_date_sequence.R:58
 msgid ""
 "Found the following unrecognised column name{?s}: {.field "
 "{target_columns[missing_cols]}}."
@@ -19,25 +19,38 @@ msgstr ""
 "L{?a/es} colonne{?s} suivante{?s} {?est/sont} invalide{?s} : {.field "
 "{target_columns[missing_cols]}}."
 
-#: check_date_sequence.R:65
+#: check_date_sequence.R:66
 msgid "Insufficient number of columns to compare."
 msgstr "Le nombre de colonne à comparer est insuffisant."
 
-#: check_date_sequence.R:66
+#: check_date_sequence.R:67
 msgid ""
 "At least two columns of type {.cls Date} are required for this operation."
 msgstr ""
 "Cette opération nécessite au moins deux noms de colonnes de type {.cls Date}."
 
-#: check_date_sequence.R:67
+#: check_date_sequence.R:68
 msgid "Have you provided an invalid column name?"
 msgstr "Avez-vous fourni un nom de colonne incorrect ?"
 
-#: check_date_sequence.R:80
+#: check_date_sequence.R:84
+msgid ""
+"Impossible to check the sequence of the date events due to missing values."
+msgstr "Impossible de vérifier la séquence des dates à cause des données "
+"manquantes."
+
+#: check_date_sequence.R:93
+msgid ""
+"Cannot check the sequence of date events across {.val {sum(is."
+"na(order_date))}} rows due to missing data."
+msgstr "La séquence des dates ne peut pas être vérifiée à travers "
+"{.val {sum(is.na(order_date))}} lignes à cause des données manquantes."
+
+#: check_date_sequence.R:103
 msgid "No incorrect date sequence was detected."
 msgstr "Aucune séquence de date invalide n'a été détectée."
 
-#: check_date_sequence.R:100
+#: check_date_sequence.R:120
 msgid ""
 "Detected {.val {length(bad_order)}} incorrect date sequence{?s} at line{?s}: "
 "{.val {toString(bad_order)}}."
@@ -46,7 +59,7 @@ msgstr ""
 "détectée{?s} à {?la/aux} ligne{?s} suivante{?s}: {.val "
 "{toString(bad_order)}}."
 
-#: check_date_sequence.R:101
+#: check_date_sequence.R:121
 msgid ""
 "Enter {.code attr(dat, \"report\")[[\"incorrect_date_sequence\"]]} to access "
 "them, where {.val dat} is the object used to store the output from this "
@@ -113,13 +126,13 @@ msgstr "Substitution de valeurs via dictionnaire des données"
 msgid "Checking whether date sequences are respected"
 msgstr "Vérification de la séquence des dates"
 
-#: clean_data_helpers.R:70
+#: clean_data_helpers.R:72
 msgid "No character column found from the input data."
 msgstr ""
 "Aucune colonne avec des valeurs de type chaîne de caractères n’a été "
 "identifiée."
 
-#: clean_data_helpers.R:91
+#: clean_data_helpers.R:93
 msgid ""
 "Found {.cls numeric} values that can also be of type {.cls Date} in the "
 "following {cli::qty(length(ambiguous_cols))} column{?s}: {.field "
@@ -129,7 +142,7 @@ msgstr ""
 "ont été identifiées dans {cli::qty(length(ambiguous_cols))} {?la/les} "
 "colonne{?s} suivante{?s}: {.field {ambiguous_cols}}."
 
-#: clean_data_helpers.R:92
+#: clean_data_helpers.R:94
 msgid ""
 "They can be converted into {.cls Date} using: {.code lubridate::as_date(x, "
 "origin = as.Date(\"1900-01-01\"))}"
@@ -137,7 +150,7 @@ msgstr ""
 "Veuillez utiliser {.code lubridate::as_date(x, origin = as."
 "Date(\"1900-01-01\"))} pour les convertir en {.cls Date}"
 
-#: clean_data_helpers.R:93
+#: clean_data_helpers.R:95
 msgid ""
 "where {.val x} represents here the vector of values from the corresponding "
 "column ({.code data$target_column})."
@@ -145,7 +158,7 @@ msgstr ""
 "où {.val x} représente le vecteur des valeurs issues de la colonne cible "
 "correspondante ({.code data$target_column})."
 
-#: column_name_standardization.R:58
+#: column_name_standardization.R:59
 msgid ""
 "Cannot rename {cli::qty(length(incorrect_col_names))} {?an/ } unrecognised "
 "column name{?s} specified in {.emph rename} argument: {.val "
@@ -155,13 +168,13 @@ msgstr ""
 "colonne{?s} fournie{?s} à l’argument {.emph rename}, mais qui n’existe{?nt} "
 "pas: {.val {toString(incorrect_col_names)}}."
 
-#: column_name_standardization.R:59
+#: column_name_standardization.R:60
 msgid "Make sure that the columns to be renamed are part of the input data."
 msgstr ""
 "Assurez-vous que toutes les colonnes à renommer fassent parti des données "
 "d’entrée."
 
-#: column_name_standardization.R:60
+#: column_name_standardization.R:61
 msgid ""
 "To rename columns, use: {.emph rename = c(new_name1 = 'old_name1', new_name2 "
 "= 'old_name2')}."
@@ -169,7 +182,7 @@ msgstr ""
 "Les noms de colonnes peuvent être renommer comme suit: {.emph rename = "
 "c(nouveau_nom1 = 'ancien_nom1', nouveau_nom2 = 'ancien_nom2')}."
 
-#: column_name_standardization.R:68
+#: column_name_standardization.R:69
 msgid ""
 "The provided replace column {cli::qty(length(existing_cols))} name{?s} "
 "already exist."
@@ -177,11 +190,11 @@ msgstr ""
 "{cli::qty(length(existing_cols))} Le{?s} nom{?s} utilisé{?s} pour renommer {?"
 "une des/certaines} colonnes existe{?nt} déjà."
 
-#: column_name_standardization.R:69
+#: column_name_standardization.R:70
 msgid "All new names must be different from existing column names."
 msgstr "Tout nouveau nom doit être différent des noms qui existent déjà."
 
-#: column_name_standardization.R:70
+#: column_name_standardization.R:71
 msgid ""
 "You must use {cli::qty(length(existing_cols))} {?a/ } different name{?s} for "
 "the following column{?s}: {.field {toString(existing_cols)}}."
@@ -190,18 +203,18 @@ msgstr ""
 "différent{?s} pour {?la/les} colonne{?s} suivante{?s} : {.field "
 "{toString(existing_cols)}}."
 
-#: convert_to_numeric.R:40
+#: convert_to_numeric.R:42
 msgid "Automatic detection of columns to convert into numeric failed."
 msgstr ""
 "Impossible de détecter automatiquement les colonnes à convertir en numérique."
 
-#: convert_to_numeric.R:41
+#: convert_to_numeric.R:43
 msgid "No character column with numeric values found by {.fn scan_data}."
 msgstr ""
 "Aucune colonne de type chaîne de caractères (character) contenant des "
 "valeurs numériques n’a été identifiée par {.fn scan_data}."
 
-#: convert_to_numeric.R:42 convert_to_numeric.R:64
+#: convert_to_numeric.R:44 convert_to_numeric.R:66
 msgid ""
 "Please specify names of the columns to convert into numeric using {.emph "
 "target_columns}."
@@ -209,7 +222,7 @@ msgstr ""
 "Veuillez spécifier les noms des colonnes à convertir en numérique à travers "
 "l’argument {.emph target_columns}."
 
-#: convert_to_numeric.R:62
+#: convert_to_numeric.R:64
 msgid ""
 "Found one or more columns with insuffisient numeric values for automatic "
 "conversion."
@@ -217,30 +230,34 @@ msgstr ""
 "Des colonnes avec un nombre insuffisant de valeurs numériques ont été "
 "identifiées."
 
-#: convert_to_numeric.R:63
+#: convert_to_numeric.R:65
+#, fuzzy
+#| msgid ""
+#| "The percent of character values must be less than twice the numeric "
+#| "values for a column to be considered for automatic conversion."
 msgid ""
-"The percent of character values must be less than twice the numeric values "
-"for a column to be considered for automatic conversion."
+"The percentage of character values must be less than twice the numeric "
+"values for a column to be considered for automatic conversion."
 msgstr ""
 "Le pourcentage de valeurs de type chaîne de caractères doit faire moins du "
 "double de celui des valeurs numériques pour qu’une colonne soit "
 "automatiquement convertie."
 
-#: convert_to_numeric.R:105
+#: convert_to_numeric.R:107
 msgid "Found {.val {num_values}} numeric value{?s} in {.field {col}}."
 msgstr ""
 "{.val {num_values}} valeur{?s} de type numérique {?a/ont} été identifiée{?s} "
 "dans la colonne: {.field {col}}."
 
-#: convert_to_numeric.R:106
+#: convert_to_numeric.R:108
 msgid "Please consider the following options:"
 msgstr "Veuillez considérer les options suivantes :"
 
-#: convert_to_numeric.R:107
+#: convert_to_numeric.R:109
 msgid "Converting characters into numeric"
 msgstr "Convertir les chaînes de caractères en numériques"
 
-#: convert_to_numeric.R:108
+#: convert_to_numeric.R:110
 msgid ""
 "Replacing the numeric values by {.val NA} using the {.fn "
 "replace_missing_values} function."
@@ -248,7 +265,7 @@ msgstr ""
 "Remplacer les valeurs numériques avec {.val NA} via la fonction {.fn "
 "replace_missing_values}."
 
-#: convert_to_numeric.R:115
+#: convert_to_numeric.R:117
 msgid ""
 "The following column{?s} will be converted into numeric: {.field "
 "{to_numeric}}."
@@ -271,17 +288,17 @@ msgstr ""
 "{.cls chaîne de caractères (character)} au format {.emph ISO8601} "
 "('2024-12-31' pour 31 Décembre 2024)."
 
-#: date_standardization_helpers.R:410
+#: date_standardization_helpers.R:412
 msgid "Expected values with the same format."
 msgstr "Les valeurs devaient avoir le même format."
 
-#: date_standardization_helpers.R:411
+#: date_standardization_helpers.R:413
 msgid "You've tried to convert values in different formats into {.cls Date}."
 msgstr ""
 "Vous avez essayé de convertir en {.cls Date} des valeurs ayant differents "
 "formats."
 
-#: date_standardization_helpers.R:412
+#: date_standardization_helpers.R:414
 msgid ""
 "Please specify the formats encountered in your column of interest via the {."
 "emph format} argument."
@@ -289,20 +306,20 @@ msgstr ""
 "Veuillez fournir les formats retrouvés dans la colonne cible via le "
 "paramètre {.emph format}."
 
-#: date_standardization_helpers.R:553
+#: date_standardization_helpers.R:556
 msgid "Unexpected data type provided to {.fn date_guess} function."
 msgstr ""
 "Le type de donnée fourni à la fonction {.fn date_guess} est différent du "
 "type que la fonction devait prendre."
 
-#: date_standardization_helpers.R:554
+#: date_standardization_helpers.R:557
 msgid ""
 "You can convert the values into {.cls character} to enable format guessing."
 msgstr ""
 "Vous pouvez convertir les valeurs en {.cls chaîne de caractères (character)} "
 "pour permettre la détection automatique de leurs formats."
 
-#: date_standardization_helpers.R:555
+#: date_standardization_helpers.R:558
 msgid ""
 "You've tried to guess the date format from values of type other than Date "
 "and character."
@@ -310,19 +327,19 @@ msgstr ""
 "Vous avez tenté de détecter le format de valeurs qui ne sont ni de type Date "
 "ou chaîne de caractères."
 
-#: date_standardization_helpers.R:574
+#: date_standardization_helpers.R:578
 msgid "Unable to match formats to target columns."
 msgstr ""
 "Impossible d’établir la correspondence entre formats et colonnes ciblées."
 
-#: date_standardization_helpers.R:575
+#: date_standardization_helpers.R:579
 msgid ""
 "The number of target columns does not match the number of specified formats."
 msgstr ""
 "Le nombre de colonnes cibles ne correspond pas au nombre de formats qui sont "
 "forunis"
 
-#: date_standardization_helpers.R:576
+#: date_standardization_helpers.R:580
 msgid ""
 "Only one format is needed if all target columns contain values of the same "
 "format. Otherwise, one format per target column must be provided."
@@ -330,7 +347,7 @@ msgstr ""
 "Seul un format est requis si les colonnes cibles ont des valeurs du même "
 "format. Sinon, vous devez fornir un format par colonne cible."
 
-#: date_standardization_helpers.R:581
+#: date_standardization_helpers.R:585
 msgid ""
 "The target {cli::qty(length(target_columns))} column{?s} will be "
 "standardized using the format: {.val {format}}."
@@ -365,11 +382,11 @@ msgstr ""
 "Entrez {.fn get_default_params} pour consulter la list des arguments "
 "prédéfinis."
 
-#: dictionary_based_cleaning.R:48
+#: dictionary_based_cleaning.R:49
 msgid "Incorrect data dictionary format."
 msgstr "Le format du dictionnaire de données est invalide."
 
-#: dictionary_based_cleaning.R:49
+#: dictionary_based_cleaning.R:50
 msgid ""
 "The value for the {.emph dictionary} argument must be a {.cls data.frame} "
 "with the following columns: {.field {toString(all_columns)}}."
@@ -377,14 +394,14 @@ msgstr ""
 "La valeur fournie a l’argument {.emph dictionary} doit être un {.cls data."
 "frame} contenant les colonnes suivantes: {.field {toString(all_columns)}}."
 
-#: dictionary_based_cleaning.R:50
+#: dictionary_based_cleaning.R:51
 msgid ""
 "The following columns are mandatory: {.field {toString(mandatory_columns)}}."
 msgstr ""
 "Les colonnes suivantes sont obligatoires : {.field "
 "{toString(mandatory_columns)}}."
 
-#: dictionary_based_cleaning.R:58
+#: dictionary_based_cleaning.R:59
 msgid ""
 "Incorrect column names specified in column {.field grp} of the data "
 "dictionary."
@@ -392,7 +409,7 @@ msgstr ""
 "La colonne {.field grp} du dictionnaire de données contient des noms de "
 "colonnes invalides."
 
-#: dictionary_based_cleaning.R:59
+#: dictionary_based_cleaning.R:60
 msgid ""
 "Values in {.field grp} column of the data dictionary must be found in the "
 "input data frame."
@@ -400,15 +417,15 @@ msgstr ""
 "Les noms de colonnes fournies dans la colonne {.field grp} du dictionnaire "
 "de données doivent figurer dans le tableau des données d’entrée (data frame)."
 
-#: dictionary_based_cleaning.R:60
+#: dictionary_based_cleaning.R:61
 msgid "Did you enter an incorrect column name?"
 msgstr "Avez-vous fourni un nom de colonne invalide ?"
 
-#: dictionary_based_cleaning.R:71
+#: dictionary_based_cleaning.R:72
 msgid "You can either:"
 msgstr "Vous pouvez soit :"
 
-#: dictionary_based_cleaning.R:72
+#: dictionary_based_cleaning.R:73
 msgid ""
 "correct the misspelled {cli::qty(length(misspelled_options))} option{?s} "
 "from the input data, or"
@@ -416,7 +433,7 @@ msgstr ""
 "corriger {cli::qty(length(misspelled_options))} {?l’option/les options} mal "
 "orthographiée{?s}, ou"
 
-#: dictionary_based_cleaning.R:73
+#: dictionary_based_cleaning.R:74
 msgid ""
 "add {cli::qty(length(misspelled_options))} {?it/them} to the dictionary "
 "using the {.fn add_to_dictionary} function."
@@ -424,7 +441,7 @@ msgstr ""
 "{cli::qty(length(misspelled_options))} {?l’ajouter/les ajouter} au "
 "dictionnaire de données en utilisant la fonction {.fn add_to_dictionary}."
 
-#: dictionary_based_cleaning.R:298
+#: dictionary_based_cleaning.R:255
 msgid ""
 "Cannot replace {.val {toString(undefined_opts)}} present in column {.field "
 "{opts}} but not defined in the dictionary."
@@ -433,11 +450,11 @@ msgstr ""
 "qty(undefined_opts)} {?trouve/trouvent} dans la colonne {.field {opts}} et "
 "non définis dans le dictionnaire de données."
 
-#: find_and_remove_duplicates.R:115
+#: find_and_remove_duplicates.R:118
 msgid "Found {.val {nrow(dups)}} duplicated row{?s} in the dataset."
 msgstr "Ces données contiennent {.val {nrow(dups)}} ligne{?s} redondante{?s}."
 
-#: find_and_remove_duplicates.R:116
+#: find_and_remove_duplicates.R:119
 msgid ""
 "Use {.code attr(dat, \"report\")[[\"duplicated_rows\"]]} to access them, "
 "where {.val dat} is the object used to store the output from this operation."
@@ -446,15 +463,15 @@ msgstr ""
 "accéder. {.val dat} represente ici l’object créé pour stocker le résultat de "
 "cette opération."
 
-#: find_and_remove_duplicates.R:132
+#: find_and_remove_duplicates.R:135
 msgid "No duplicates were found."
 msgstr "Aucune ligne redondante n’a été détectée."
 
-#: guess_dates.R:85
+#: guess_dates.R:86
 msgid "Incorrect value provided to the {.emph order} argument."
 msgstr "La valeur fournie à l’argument {.emph order} est invalide."
 
-#: guess_dates.R:86
+#: guess_dates.R:87
 msgid ""
 "Value for {.emph order} argument must be either a {.cls character} or a {."
 "cls list} of character vectors."
@@ -463,11 +480,11 @@ msgstr ""
 "caractères ou une {.cls liste} d’un ou plusieurs vecteurs de chaînes de "
 "caractères."
 
-#: print_report.R:78
+#: print_report.R:81
 msgid "No report associated with the input data."
 msgstr "Pas de rapport associé à ce tableau de données."
 
-#: print_report.R:79
+#: print_report.R:82
 msgid ""
 "At least one data cleaning operation must be applied to the data before "
 "calling {.fn print_report}."
@@ -475,7 +492,7 @@ msgstr ""
 "Au moins une opération de nettoyage de données doit être appliquée aux "
 "données avant d’évoquer la fonction {.fn print_report}."
 
-#: print_report.R:80
+#: print_report.R:83
 msgid ""
 "The list of functions in {.pkg cleanepi} can be found at: {.url https://"
 "epiverse-trace.github.io/cleanepi/reference/index.html}."
@@ -484,19 +501,19 @@ msgstr ""
 "travers le lien suivant : {.url https://epiverse-trace.github.io/cleanepi/"
 "reference/index.html}."
 
-#: print_report.R:85
+#: print_report.R:88
 msgid "Incorrect value provided for {.emph format} argument!"
 msgstr "La valeur fournie à l’argument {.emph format} est invalide."
 
-#: print_report.R:86
+#: print_report.R:89
 msgid "Only {.val html} format is currently supported."
 msgstr "Seul le format {.val html} est accepté pour le moment."
 
-#: print_report.R:112
+#: print_report.R:115
 msgid "Generating html report in {.file {temp_dir}}."
 msgstr "Creation du rapport en format html dans {.file {temp_dir}}."
 
-#: remove_constants.R:122
+#: remove_constants.R:124
 msgid ""
 "Constant data was removed after {.val {nrow(constant_data_report)}} "
 "iteration{?s}."
@@ -504,7 +521,7 @@ msgstr ""
 "Les données constantes ont été supprimées après {.val "
 "{nrow(constant_data_report)}} iteration{?s}."
 
-#: remove_constants.R:123
+#: remove_constants.R:125
 msgid ""
 "Enter {.code attr(dat, \"report\")[[\"constant_data\"]]} for more "
 "information, where {.val dat} represents the object used to store the output "
@@ -514,7 +531,7 @@ msgstr ""
 "d’information. {.val dat} represente ici l’object créé pour stocker le "
 "résultat de la fonction {.fn remove_constants}."
 
-#: replace_missing_values.R:56
+#: replace_missing_values.R:55
 msgid ""
 "Could not detect the provided missing value {cli::qty(length(na_strings))} "
 "character{?s}."
@@ -522,7 +539,7 @@ msgstr ""
 "Impossible de détecter {cli::qty(length(na_strings))} {?la/les} chaîne{?s} "
 "de caractères représentant les valeurs manquantes."
 
-#: replace_missing_values.R:57
+#: replace_missing_values.R:56
 msgid ""
 "Does your data contain missing value characters other than the specified "
 "ones?"
@@ -530,18 +547,18 @@ msgstr ""
 "Vos données contiennent-elles d’autres chaînes de caractères utilisées pour  "
 "représenter les valeurs manquantes ?"
 
-#: span.R:85
+#: span.R:88
 msgid "Unexpected type in the value for argument {.emph end_date}."
 msgstr "Le type de la valeur de l’argument {.emph end_date} est invalide."
 
-#: span.R:86
+#: span.R:89
 msgid ""
 "You provided a name of a column of type {.cls {class(data[[end_date]])}}."
 msgstr ""
 " Vous avez fourni le nom d’une colonne de type {.cls "
 "{class(data[[end_date]])}}."
 
-#: span.R:87
+#: span.R:90
 msgid ""
 "The value for {.emph end_date} argument must be of type {.cls Date} in {."
 "emph ISO8601} format."
@@ -549,7 +566,7 @@ msgstr ""
 "La valeur de l’argument {.emph end_date} doit être de type {.cls Date} dans "
 "un format {.emph ISO8601}."
 
-#: standardize_date.R:184
+#: standardize_date.R:190
 msgid ""
 "Found {.cls numeric} values that could also be of type {.cls Date} in {cli::"
 "qty(length(ambiguous_cols))} column{?s}: {.field {toString(ambiguous_cols)}}."
@@ -558,7 +575,7 @@ msgstr ""
 "ont été identifiées dans {cli::qty(length(ambiguous_cols))} {?la/les} "
 "colonne{?s} suivante{?s}: {.field {ambiguous_cols}}."
 
-#: standardize_date.R:185
+#: standardize_date.R:191
 msgid ""
 "It is possible to convert them into {.cls Date} using: {.code lubridate::"
 "as_date(x, origin = as.Date(\"1900-01-01\"))}"
@@ -566,7 +583,7 @@ msgstr ""
 "Veuillez entrer {.code lubridate::as_date(x, origin = as."
 "Date(\"1900-01-01\"))} pour les convertir en {.cls Date}."
 
-#: standardize_date.R:186
+#: standardize_date.R:192
 msgid ""
 "where {.val x} represents here the vector of values from these columns ({."
 "code data$target_column})."
@@ -574,11 +591,11 @@ msgstr ""
 "où {.val x} représente le vecteur des valeurs issues des colonnes cibles ({."
 "code data$target_column})."
 
-#: standardize_subject_ids.R:87
+#: standardize_subject_ids.R:90
 msgid "No incorrect subject id was detected."
 msgstr "Aucun identifiant invalide n'a été détecté."
 
-#: standardize_subject_ids.R:100
+#: standardize_subject_ids.R:103
 msgid ""
 "Detected {.val {length(bad_rows)}} invalid subject id{?s} at line{?s}: {.val "
 "{toString(bad_rows)}}."
@@ -587,7 +604,7 @@ msgstr ""
 "détectée{?s} à {?la/aux} ligne{?s} suivante{?s}: {.val "
 "{toString(bad_order)}}."
 
-#: standardize_subject_ids.R:101
+#: standardize_subject_ids.R:104
 msgid ""
 "You can use the {.fn correct_subject_ids} function to correct {cli::"
 "qty(length(bad_rows))} {?it/them}."
@@ -595,22 +612,30 @@ msgstr ""
 "Vous pouvez {cli::qty(length(bad_rows))} le{?s} corriger en utilisant la "
 "fonction {.fn correct_subject_ids}."
 
-#: standardize_subject_ids.R:163
+#: standardize_subject_ids.R:166
+#, fuzzy
+#| msgid ""
+#| "Some ids specified in the correction table were not found in the input "
+#| "data."
 msgid ""
-"Some ids specified in the correction table were not found in the input data."
+"Some IDs specified in the correction table were not found in the input data."
 msgstr ""
 "Certains identifiants fournis dans la table de correction ne figurent pas "
 "dans les données d’entrée."
 
-#: standardize_subject_ids.R:164
+#: standardize_subject_ids.R:167
+#, fuzzy
+#| msgid ""
+#| "Values in the {.field from} column of the correction table must be part "
+#| "of the detected incorrect subject ids."
 msgid ""
 "Values in the {.field from} column of the correction table must be part of "
-"the detected incorrect subject ids."
+"the detected incorrect subject IDs."
 msgstr ""
 "Les valeurs fournies à la colonne {.field from} de la table de correction "
 "doivent être parmi les identifiants incorrects qui ont été détectés."
 
-#: standardize_subject_ids.R:192
+#: standardize_subject_ids.R:196
 msgid ""
 "Missing {cli::qty(length(idx))} value{?s} found in {.field {id_col_name}} "
 "column at line{?s}: {.val {toString(idx)}}."
@@ -619,13 +644,15 @@ msgstr ""
 "retrouvée{?s} à la colonne {.field {id_col_name}} {cli::qty(length(idx))}{?à "
 "la/aux} ligne{?s} : {.val {toString(idx)}}."
 
-#: standardize_subject_ids.R:209
-msgid "Found {.val {num_dup_rows}} duplicated value{?s} in the subject ids."
+#: standardize_subject_ids.R:213
+#, fuzzy
+#| msgid "Found {.val {num_dup_rows}} duplicated value{?s} in the subject ids."
+msgid "Found {.val {num_dup_rows}} duplicated value{?s} in the subject Ids."
 msgstr ""
 "{.val {num_dup_rows}} valeur{?s} redondante{?s} {?a/ont} été retrouvée{?s} "
 "dans la colonne contenant les identifiants des individus."
 
-#: standardize_subject_ids.R:210
+#: standardize_subject_ids.R:214
 msgid ""
 "Enter {.code attr(dat, \"report\")[[\"duplicated_rows\"]]} to access them, "
 "where {.val dat} is the object used to store the output from this operation."
@@ -634,7 +661,7 @@ msgstr ""
 "accéder. {.val dat} represente ici l’object créé pour stocker le résultat de "
 "cette opération."
 
-#: utils.R:147
+#: utils.R:133
 msgid ""
 "Could not find the following column name{?s}: {.field {target_columns[is."
 "na(idx)]}}"
@@ -642,35 +669,35 @@ msgstr ""
 "Les données ne contiennent pas le{?s} nom{?s} de colonnes suivant{?s} : {."
 "field {target_columns[missing_cols]}}."
 
-#: utils.R:148
+#: utils.R:134
 msgid ""
 "Please make sure that all specified target columns belong to the input data."
 msgstr ""
 "Assurez-vous que toutes les colonnes cibles fassent parti des données "
 "d’entrée."
 
-#: utils.R:159
+#: utils.R:145
 msgid "Some column indices are out of bound."
 msgstr "Certains numéros de colonne sont hors de la limite."
 
-#: utils.R:160
+#: utils.R:146
 msgid "Column indices must be between {.val {1}} and {.val {ncol(data)}}."
 msgstr ""
 "Les numéros des colonnes cibles doivent être compris entre {.val {1}} et {."
 "val {ncol(data)}}."
 
-#: utils.R:161
+#: utils.R:147
 msgid "You provided indices for columns that do not exist."
 msgstr ""
 "Vous avez fourni des numéros de colonne supérieurs au nombre total de "
 "colonnes dans vos données."
 
-#: utils.R:171
+#: utils.R:157
 msgid "Invalid value for {.emph target_columns}."
 msgstr ""
 "La valeur fournie pour l’argument {.emph target_columns} est incorrecte."
 
-#: utils.R:172
+#: utils.R:158
 msgid ""
 "{.val linelist_tags} only works on {.cls linelist} objects. You can provide "
 "a {.cls vector} of column names for inputs of class {.cls data.frame}."
@@ -679,19 +706,19 @@ msgstr ""
 "linelist} uniquement. Vous pouvez fournir un {.cls vecteur} de noms de "
 "colonnes pour les données de class {.cls data.frame}."
 
-#: utils.R:186
+#: utils.R:172
 msgid "The specified target columns are either constant or empty."
 msgstr "Les colonnes cibles sont soit constantes ou vides."
 
-#: utils.R:187
+#: utils.R:173
 msgid "Please consider using:"
 msgstr "Veuillez considérer utiliser :"
 
-#: utils.R:188
+#: utils.R:174
 msgid "the names of columns that are neither constant or empty, or"
 msgstr "des noms de colonnes qui sont ni vides ni constantes, ou bien"
 
-#: utils.R:189
+#: utils.R:175
 msgid "{.fn remove_constants} prior to this cleaning operation."
 msgstr "la fonction {.fn remove_constants} avant cette opération."
 

--- a/tests/testthat/test-check_date_sequence.R
+++ b/tests/testthat/test-check_date_sequence.R
@@ -76,7 +76,7 @@ test_that("check_date_sequence works as expected when target_column is provided
               expect_identical(ncol(report[["incorrect_date_sequence"]]), 3L)
               expect_identical(
                 names(report[["incorrect_date_sequence"]]),
-                c("row_id", "date_first_pcr_positive_test", "date.of.admission")
+                c("date_first_pcr_positive_test", "date.of.admission", "row_id")
               )
 })
 


### PR DESCRIPTION
This PR contains changes that are addressing the error thrown by `check_date_sequence()` when there are missing values in one of the columns.
