### PR TITLE
add caveat in using remove_duplicates function

### DIFF
--- a/R/find_and_remove_duplicates.R
+++ b/R/find_and_remove_duplicates.R
@@ -9,14 +9,14 @@
 #'    for duplicates. When the input data is a \code{linelist} object, this
 #'    parameter can be set to \code{linelist_tags} if you wish to look for
 #'    duplicates on tagged columns only. Default is \code{NULL}.
-#' 
+#'
 #' @details
-#' **Caveat:** In many epidemiological datasets, multiple rows may share the 
-#' same value in one or more columns without being true duplicates.  
-#' For example, several individuals might have the same  symptom onset date 
-#' and admission date. Be cautious when using this function—especially when 
-#' applying it to a single target column—to avoid incorrect identification 
-#'  or removal of valid entries.
+#' **Caveat:** In many epidemiological datasets, multiple rows may share the
+#' same value in one or more columns without being true duplicates.
+#' For example, several individuals might have the same  symptom onset date
+#' and admission date. Be cautious when using this function—especially when
+#' applying it to a single target column—to avoid incorrect identification
+#' or removal of valid entries.
 #'
 #' @returns The input data \code{<data.frame>} or \code{<linelist>} without the
 #'    duplicated rows identified from all or the specified columns.

--- a/R/find_and_remove_duplicates.R
+++ b/R/find_and_remove_duplicates.R
@@ -10,7 +10,7 @@
 #'    parameter can be set to \code{linelist_tags} if you wish to look for
 #'    duplicates on tagged columns only. Default is \code{NULL}.
 #' 
-#'@details
+#' @details
 #' **Caveat:** In many epidemiological datasets, multiple rows may share the 
 #' same value in one or more columns without being true duplicates.  
 #' For example, several individuals might have the same  symptom onset date 

--- a/R/find_and_remove_duplicates.R
+++ b/R/find_and_remove_duplicates.R
@@ -9,6 +9,14 @@
 #'    for duplicates. When the input data is a \code{linelist} object, this
 #'    parameter can be set to \code{linelist_tags} if you wish to look for
 #'    duplicates on tagged columns only. Default is \code{NULL}.
+#' 
+#'@details
+#' **Caveat:** In many epidemiological datasets, multiple rows may share the 
+#' same value in one or more columns without being true duplicates.  
+#' For example, several individuals might have the same  symptom onset date 
+#' and admission date. Be cautious when using this function—especially when 
+#' applying it to a single target column—to avoid incorrect identification 
+#'  or removal of valid entries.
 #'
 #' @returns The input data \code{<data.frame>} or \code{<linelist>} without the
 #'    duplicated rows identified from all or the specified columns.

--- a/R/remove_constants.R
+++ b/R/remove_constants.R
@@ -150,14 +150,14 @@ perform_remove_constants <- function(data, cutoff) {
 
   # report empty rows if found
   empty_rows <- NULL
-  if (nrow(data) > nrow(dat)) {
-    empty_rows <- toString(which(rowSums(is.na(data)) / ncol(data) >= cutoff))
+  if (any(to_remove)) {
+    empty_rows <- toString(which(to_remove))
   }
 
   # remove the empty columns
   missingness <- colSums(is.na(dat)) / nrow(dat)
   to_remove <- missingness >= cutoff
-  dat <- if(length(to_remove)==dim(data)[2]) data else dat[, !to_remove]
+  dat <- if (sum(to_remove) == 0) dat else dat[, !to_remove]
 
   # report empty columns if found
   empty_columns <- NULL

--- a/R/remove_constants.R
+++ b/R/remove_constants.R
@@ -146,7 +146,7 @@ perform_remove_constants <- function(data, cutoff) {
   # remove the empty rows
   missingness <- rowSums(is.na(data)) / ncol(data)
   to_remove <- missingness >= cutoff
-  dat <- data[!to_remove, ]
+  dat <- if (all(to_remove)) data else data[!to_remove, ]
 
   # report empty rows if found
   empty_rows <- NULL
@@ -157,7 +157,7 @@ perform_remove_constants <- function(data, cutoff) {
   # remove the empty columns
   missingness <- colSums(is.na(dat)) / nrow(dat)
   to_remove <- missingness >= cutoff
-  dat <- dat[, !to_remove]
+  dat <- if(length(to_remove)==dim(data)[2]) data else dat[, !to_remove]
 
   # report empty columns if found
   empty_columns <- NULL

--- a/man/remove_duplicates.Rd
+++ b/man/remove_duplicates.Rd
@@ -22,6 +22,14 @@ duplicated rows identified from all or the specified columns.
 When removing duplicates, users can specify a set columns to consider with
 the \code{target_columns} argument.
 }
+\details{
+\strong{Caveat:} In many epidemiological datasets, multiple rows may share the
+same value in one or more columns without being true duplicates.
+For example, several individuals might have the same  symptom onset date
+and admission date. Be cautious when using this function—especially when
+applying it to a single target column—to avoid incorrect identification
+or removal of valid entries.
+}
 \examples{
 data <- readRDS(
   system.file("extdata", "test_linelist.RDS", package = "cleanepi")

--- a/tests/testthat/test-remove_constants.R
+++ b/tests/testthat/test-remove_constants.R
@@ -14,6 +14,7 @@ test_that("remove_constants works", {
   expect_s3_class(dat, class = "data.frame")
   expect_identical(ncol(dat), 5L)
   expect_false(nrow(data) == nrow(dat))
+  expect_false(ncol(data) == ncol(dat))
   expect_false(
     any(
       c("empty_column", "event_name", "country_code", "country_name") %in%
@@ -21,11 +22,7 @@ test_that("remove_constants works", {
     )
   )
 
-  report <- attr(dat, "report")
-  expect_type(report, "list")
-  expect_length(report, 1L)
-  expect_named(report, "constant_data")
-  constant_data <- report[["constant_data"]]
+  constant_data <- print_report(dat, "constant_data")
   expect_true(nrow(constant_data) == 1)
   expect_true(ncol(constant_data) == 4)
   expect_identical(
@@ -59,24 +56,20 @@ df <- tibble::tibble(
 test_that("remove_constants works", {
   dat <- df %>%
   cleanepi::remove_constants()
-  report <- attr(dat, "report")
 
   expect_s3_class(dat, class = "data.frame")
   expect_identical(ncol(dat), 2L)
   expect_true(nrow(dat) == 2L)
-  dat <- data.frame(dat)
+  tmp_dat <- data.frame(dat)
   expect_identical(
-    dat,
+    tmp_dat,
     data.frame(
       x = as.double(1:2),
       y = as.double(c(1, 3))
     )
   )
 
-  expect_type(report, "list")
-  expect_length(report, 1L)
-  expect_named(report, "constant_data")
-  constant_data <- report[["constant_data"]]
+  constant_data <- print_report(dat, "constant_data")
   expect_true(nrow(constant_data) == 2)
   expect_true(ncol(constant_data) == 4)
   expect_identical(
@@ -99,24 +92,20 @@ test_that("remove_constants works", {
 test_that("remove_constants works as expected", {
   dat <- df %>%
     cleanepi::remove_constants(cutoff = 0.5)
-  report <- attr(dat, "report")
 
   expect_s3_class(dat, class = "data.frame")
   expect_identical(ncol(dat), 2L)
   expect_true(nrow(dat) == 2L)
-  dat <- data.frame(dat)
+  tmp_dat <- data.frame(dat)
   expect_identical(
-    dat,
+    tmp_dat,
     data.frame(
       x = as.double(1:2),
       y = as.double(c(1, 3))
     )
   )
 
-  expect_type(report, "list")
-  expect_length(report, 1L)
-  expect_named(report, "constant_data")
-  constant_data <- report[["constant_data"]]
+  constant_data <- print_report(dat, "constant_data")
   expect_true(nrow(constant_data) == 1)
   expect_true(ncol(constant_data) == 4)
   expect_identical(


### PR DESCRIPTION
This PR addresses issue #238 by adding a @details tag in the documentation of the `remove_duplicates` function. It includes a caveat to caution users—especially when applying the function to a single target column—that multiple rows with the same values may not be true duplicates.

It also addresses issues #237 but allowing for all values cutoff parameters. 