### PR TITLE
Enhance `replace_missing_values()` to match insensitive to case and whitespace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cleanepi (development version)
 
+* `replace_missing_values()` now matches with `na_strings` insensitive to
+case or leading/trailing whitespace (#257, @joshwlambert). 
+
 # cleanepi 1.1.1
 
 ## Bug fixes

--- a/R/replace_missing_values.R
+++ b/R/replace_missing_values.R
@@ -11,7 +11,7 @@
 #'    \code{cleanepi::common_na_strings}. However, if the missing values string
 #'    in the columns of interest is not included in this predefined vector,
 #'    it can be used as the value for this argument. Matching of `data` with
-#'    `na_strings` is insensitive to case and whitespace.
+#'    `na_strings` is insensitive to case and leading/trailing whitespace.
 #'
 #' @returns The input data where missing values are replaced by \code{NA}.
 #' @export

--- a/man/replace_missing_values.Rd
+++ b/man/replace_missing_values.Rd
@@ -23,7 +23,8 @@ tagged columns only.}
 values in the columns of interest. By default, it utilizes
 \code{cleanepi::common_na_strings}. However, if the missing values string
 in the columns of interest is not included in this predefined vector,
-it can be used as the value for this argument.}
+it can be used as the value for this argument. Matching of \code{data} with
+\code{na_strings} is insensitive to case and whitespace.}
 }
 \value{
 The input data where missing values are replaced by \code{NA}.

--- a/man/replace_missing_values.Rd
+++ b/man/replace_missing_values.Rd
@@ -24,7 +24,7 @@ values in the columns of interest. By default, it utilizes
 \code{cleanepi::common_na_strings}. However, if the missing values string
 in the columns of interest is not included in this predefined vector,
 it can be used as the value for this argument. Matching of \code{data} with
-\code{na_strings} is insensitive to case and whitespace.}
+\code{na_strings} is insensitive to case and leading/trailing whitespace.}
 }
 \value{
 The input data where missing values are replaced by \code{NA}.

--- a/tests/testthat/test-replace_missing_values.R
+++ b/tests/testthat/test-replace_missing_values.R
@@ -29,6 +29,15 @@ test_that("replace_missing_values works when target_columns is set to NULL", {
   )
 })
 
+test_that("replace_missing_values is case and whitespace insensitive", {
+  data$country_name[1] <- "Not avaiLablE"
+  data$country_name[2] <- " Not available "
+  cleaned_data <- replace_missing_values(data = data)
+  expect_s3_class(cleaned_data, "data.frame")
+  expect_false("Not avaiLablE" %in% cleaned_data[["country_name"]])
+  expect_true(anyNA(cleaned_data[["country_name"]]))
+})
+
 test_that("replace_missing_values fails as expected", {
   expect_message(
     replace_missing_values(


### PR DESCRIPTION
This PR enhances the `replace_missing_values()` function by normalising the input `data` so that it can be matched with the `na_string` (`common_na_strings` by default) insensitive to case (i.e. upper or lowercase) or whitespace. 

Here is a reprex using the release version of {cleanepi}:

``` r
cleanepi::common_na_strings
#>  [1] "missing"       "NA"            "N A"           "N/A"          
#>  [5] "#N/A"          "NA "           " NA"           "N /A"         
#>  [9] "N / A"         " N / A"        "N / A "        "na"           
#> [13] "n a"           "n/a"           "na "           " na"          
#> [17] "n /a"          "n / a"         " a / a"        "n / a "       
#> [21] "NULL"          "null"          ""              "\\?"          
#> [25] "\\*"           "\\."           "not available" "Not Available"
#> [29] "NOt available" "not avail"     "Not Avail"     "nan"          
#> [33] "NAN"           "not a number"  "Not A Number"

data <- readRDS(
  system.file("extdata", "test_df.RDS", package = "cleanepi")
)
data$country_name[1] <- "Not available "

cleanepi::replace_missing_values(data)
#> ! Could not detect the provided missing value characters.
#> ℹ Does your data contain missing value characters other than the specified
#>   ones?
#>     study_id event_name country_code  country_name date.of.admission
#> 1    PS001P2      day 0            2 Not available        01/12/2020
#> 2    PS002P2      day 0            2        Gambia        28/01/2021
#> 3  PS004P2-1      day 0            2        Gambia        15/02/2021
#> 4    PS003P2      day 0            2        Gambia        11/02/2021
#> 5    P0005P2      day 0            2        Gambia        17/02/2021
#> 6    PS006P2      day 0            2        Gambia        17/02/2021
#> 7    PB500P2      day 0            2        Gambia        28/02/2021
#> 8    PS008P2      day 0            2        Gambia        22/02/2021
#> 9    PS010P2      day 0            2        Gambia        02/03/2021
#> 10   PS011P2      day 0            2        Gambia        05/03/2021
#>    dateOfBirth date_first_pcr_positive_test sex
#> 1   06/01/1972                 Dec 01, 2020   1
#> 2   02/20/1952                 Jan 01, 2021   1
#> 3   06/15/1961                 Feb 11, 2021 -99
#> 4   11/11/1947                 Feb 01, 2021   1
#> 5   09/26/2000                 Feb 16, 2021   2
#> 6          -99                 May 02, 2021   2
#> 7   11/03/1989                 Feb 19, 2021   1
#> 8   10/05/1976                 Sep 20, 2021   2
#> 9   09/23/1991                 Feb 26, 2021   1
#> 10  02/08/1991                 Mar 03, 2021   2
```

<sup>Created on 2025-08-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Because the specific version of "Not available" is not in the `cleanepi::common_na_strings` vector (capital "N", lowercase "a") it does not replace it with `NA`. 

Another reprex with the updates to {cleanepi} in this PR show this is now resolved:

``` r
cleanepi::common_na_strings
#>  [1] "missing"       "NA"            "N A"           "N/A"          
#>  [5] "#N/A"          "NA "           " NA"           "N /A"         
#>  [9] "N / A"         " N / A"        "N / A "        "na"           
#> [13] "n a"           "n/a"           "na "           " na"          
#> [17] "n /a"          "n / a"         " a / a"        "n / a "       
#> [21] "NULL"          "null"          ""              "\\?"          
#> [25] "\\*"           "\\."           "not available" "Not Available"
#> [29] "NOt available" "not avail"     "Not Avail"     "nan"          
#> [33] "NAN"           "not a number"  "Not A Number"

data <- readRDS(
  system.file("extdata", "test_df.RDS", package = "cleanepi")
)
data$country_name[1] <- "Not available "

cleanepi::replace_missing_values(data)
#>     study_id event_name country_code country_name date.of.admission dateOfBirth
#> 1    PS001P2      day 0            2         <NA>        01/12/2020  06/01/1972
#> 2    PS002P2      day 0            2       gambia        28/01/2021  02/20/1952
#> 3  PS004P2-1      day 0            2       gambia        15/02/2021  06/15/1961
#> 4    PS003P2      day 0            2       gambia        11/02/2021  11/11/1947
#> 5    P0005P2      day 0            2       gambia        17/02/2021  09/26/2000
#> 6    PS006P2      day 0            2       gambia        17/02/2021         -99
#> 7    PB500P2      day 0            2       gambia        28/02/2021  11/03/1989
#> 8    PS008P2      day 0            2       gambia        22/02/2021  10/05/1976
#> 9    PS010P2      day 0            2       gambia        02/03/2021  09/23/1991
#> 10   PS011P2      day 0            2       gambia        05/03/2021  02/08/1991
#>    date_first_pcr_positive_test sex
#> 1                  Dec 01, 2020   1
#> 2                  Jan 01, 2021   1
#> 3                  Feb 11, 2021 -99
#> 4                  Feb 01, 2021   1
#> 5                  Feb 16, 2021   2
#> 6                  May 02, 2021   2
#> 7                  Feb 19, 2021   1
#> 8                  Sep 20, 2021   2
#> 9                  Feb 26, 2021   1
#> 10                 Mar 03, 2021   2
```

<sup>Created on 2025-08-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

* **Please check if the PR fulfills these requirements**

- [X] I have read the CONTRIBUTING guidelines
- [X] A new item has been added to `NEWS.md`
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [X] Checks have been run locally and pass

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
