### PR TITLE
Update `WORDLIST`

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,6 +1,8 @@
 CMD
 Codecov
+DOI
 Epiverse
+iteratively
 LSHTM
 Levenshtein
 Lifecycle
@@ -44,6 +46,7 @@ potools
 reactable
 readepi
 readr
+repo
 rlang
 rmarkdown
 snakecase


### PR DESCRIPTION
While working on the {cleanepi} package I noticed that `spelling::spell_check_package()` returned some spelling errors. These were:

```r
  WORD          FOUND IN
DOI           README.md:22
              README.Rmd:38
iteratively   remove_constants.Rd:23
              cleanepi.Rmd:363
              design_principle.Rmd:205
repo          README.Rmd:196
```

None of the flagged words are spelling mistakes, so in this PR I've updated the `WORDLIST` file in `inst/` so these are added to the dictionary when the package is spell checked. 